### PR TITLE
Update frontend dependencies to fix security vulnerabilities

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,13 +22,13 @@
     "moment": "^2.30.1",
     "moment-timezone": "^0.6.0",
     "prop-types": "^15.8.1",
-    "react": "^19.0.0",
+    "react": "^19.2.4",
     "react-cookie": "^8.0.0",
     "react-datetime-picker": "^7.0.0",
-    "react-dom": "^19.0.0",
+    "react-dom": "^19.2.4",
     "react-hook-form": "^7.52.2",
     "react-redux": "^9.1.2",
-    "react-router-dom": "^7.0.0",
+    "react-router-dom": "^7.14.0",
     "redux-thunk": "^3.1.0",
     "web-vitals": "^5.0.0"
   },
@@ -66,7 +66,14 @@
     "globals": "^17.0.0",
     "jsdom": "^28.1.0",
     "prettier": "^3.0.0",
-    "vite": "^8.0.0",
+    "vite": "^8.0.5",
     "vitest": "^4.0.18"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion": "^1.1.13",
+      "flatted": "^3.4.2",
+      "undici": "^7.24.7"
+    }
   }
 }


### PR DESCRIPTION
Updated frontend dependencies to address several high-severity security vulnerabilities. The changes include:
- Bumping `vite` to `^8.0.5` to fix path traversal and arbitrary file read issues.
- Updating `react`, `react-dom` to `^19.2.4` and `react-router-dom` to `^7.14.0`.
- Adding `pnpm.overrides` for `brace-expansion (^1.1.13)`, `flatted (^3.4.2)`, and `undici (^7.24.7)` to secure transitive dependencies against DoS and prototype pollution vulnerabilities.
- Verified resolution via `pnpm audit` and ensured project stability through unit testing.
- Backend dependencies were verified to be already on their latest secure March 2026 versions.

---
*PR created automatically by Jules for task [13606960803758988176](https://jules.google.com/task/13606960803758988176) started by @Tyler-Cash*