### PR TITLE
fix(auth): resolve display names per-guild instead of overwriting wit…

### DIFF
--- a/backend/src/main/java/dev/tylercash/event/db/repository/DiscordGuildMemberRepository.java
+++ b/backend/src/main/java/dev/tylercash/event/db/repository/DiscordGuildMemberRepository.java
@@ -1,0 +1,33 @@
+package dev.tylercash.event.db.repository;
+
+import dev.tylercash.event.discord.model.DiscordGuildMember;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DiscordGuildMemberRepository extends JpaRepository<DiscordGuildMember, DiscordGuildMember.PK> {
+
+    Optional<DiscordGuildMember> findByGuildIdAndSnowflake(long guildId, String snowflake);
+
+    List<DiscordGuildMember> findAllByGuildIdAndSnowflakeIn(long guildId, Collection<String> snowflakes);
+
+    boolean existsByGuildIdAndSnowflake(long guildId, String snowflake);
+
+    @Query("select m.guildId from DiscordGuildMember m where m.snowflake = :snowflake")
+    List<Long> findGuildIdsBySnowflake(@Param("snowflake") String snowflake);
+
+    @Query(
+            """
+            select case when count(m1) > 0 then true else false end
+            from DiscordGuildMember m1, DiscordGuildMember m2
+            where m1.guildId = m2.guildId
+            and m1.snowflake = :u1
+            and m2.snowflake = :u2
+            """)
+    boolean haveSharedGuild(@Param("u1") String u1, @Param("u2") String u2);
+}

--- a/backend/src/main/java/dev/tylercash/event/db/repository/DiscordUserCacheRepository.java
+++ b/backend/src/main/java/dev/tylercash/event/db/repository/DiscordUserCacheRepository.java
@@ -1,37 +1,12 @@
 package dev.tylercash.event.db.repository;
 
 import dev.tylercash.event.discord.model.DiscordUserCache;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DiscordUserCacheRepository extends JpaRepository<DiscordUserCache, String> {
     List<DiscordUserCache> findAllBySnowflakeIn(Collection<String> snowflakes);
-
-    List<DiscordUserCache> findAllByUpdatedAtBefore(Instant cutoff);
-
-    @Query(
-            value =
-                    """
-            SELECT EXISTS (
-                SELECT 1 FROM discord_user_guild m1
-                JOIN discord_user_guild m2 ON m1.guild_id = m2.guild_id
-                WHERE m1.snowflake = :u1 AND m2.snowflake = :u2
-            )
-            """,
-            nativeQuery = true)
-    boolean haveSharedGuild(@Param("u1") String u1, @Param("u2") String u2);
-
-    @Query(
-            value = "SELECT COUNT(*) > 0 FROM discord_user_guild WHERE snowflake = :snowflake AND guild_id = :guildId",
-            nativeQuery = true)
-    boolean isUserInGuild(@Param("snowflake") String snowflake, @Param("guildId") long guildId);
-
-    @Query(value = "SELECT guild_id FROM discord_user_guild WHERE snowflake = :snowflake", nativeQuery = true)
-    List<Long> findGuildIdsBySnowflake(@Param("snowflake") String snowflake);
 }

--- a/backend/src/main/java/dev/tylercash/event/discord/AvatarController.java
+++ b/backend/src/main/java/dev/tylercash/event/discord/AvatarController.java
@@ -1,7 +1,7 @@
 package dev.tylercash.event.discord;
 
-import dev.tylercash.event.db.repository.DiscordUserCacheRepository;
-import dev.tylercash.event.discord.model.DiscordUserCache;
+import dev.tylercash.event.db.repository.DiscordGuildMemberRepository;
+import dev.tylercash.event.discord.model.DiscordGuildMember;
 import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AvatarController {
 
-    private final DiscordUserCacheRepository cacheRepository;
+    private final DiscordGuildMemberRepository memberRepository;
     private final ObjectProvider<DiscordService> discordServiceProvider;
     private final DiscordConfiguration discordConfiguration;
     private final DiscordUserCacheService cacheService;
@@ -37,13 +37,14 @@ public class AvatarController {
         }
 
         String viewerSnowflake = principal.getAttribute("id");
-        if (viewerSnowflake == null || !cacheRepository.haveSharedGuild(viewerSnowflake, snowflake)) {
+        if (viewerSnowflake == null || !memberRepository.haveSharedGuild(viewerSnowflake, snowflake)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        Optional<DiscordUserCache> cached = cacheRepository.findById(snowflake);
+        long guildId = discordConfiguration.getGuildId();
+        Optional<DiscordGuildMember> cached = memberRepository.findByGuildIdAndSnowflake(guildId, snowflake);
         if (cached.isPresent() && cached.get().getAvatarBytes() != null) {
-            DiscordUserCache entry = cached.get();
+            DiscordGuildMember entry = cached.get();
             String ct = entry.getAvatarContentType();
             MediaType mediaType;
             try {
@@ -63,17 +64,15 @@ public class AvatarController {
         try {
             DiscordService discordService = discordServiceProvider.getIfAvailable();
             if (discordService != null) {
-                Member member = discordService.getMemberFromServer(
-                        discordConfiguration.getGuildId(), Long.parseLong(snowflake));
+                Member member = discordService.getMemberFromServer(guildId, Long.parseLong(snowflake));
                 if (member != null) {
                     String avatarUrl = member.getEffectiveAvatar().getUrl(256);
-                    // Trigger async cache update for next time
                     cacheService.upsertUser(
                             snowflake,
                             DiscordUtil.getUserDisplayName(member),
                             member.getUser().getName(),
                             avatarUrl,
-                            discordConfiguration.getGuildId());
+                            guildId);
 
                     return ResponseEntity.status(HttpStatus.FOUND)
                             .location(URI.create(avatarUrl))

--- a/backend/src/main/java/dev/tylercash/event/discord/DiscordUserCacheService.java
+++ b/backend/src/main/java/dev/tylercash/event/discord/DiscordUserCacheService.java
@@ -3,9 +3,11 @@ package dev.tylercash.event.discord;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import dev.tylercash.event.db.repository.AttendanceRepository;
+import dev.tylercash.event.db.repository.DiscordGuildMemberRepository;
 import dev.tylercash.event.db.repository.DiscordUserCacheRepository;
 import dev.tylercash.event.db.repository.EventRepository;
 import dev.tylercash.event.discord.AvatarDownloadService.AvatarBytes;
+import dev.tylercash.event.discord.model.DiscordGuildMember;
 import dev.tylercash.event.discord.model.DiscordUserCache;
 import io.micrometer.observation.annotation.Observed;
 import java.time.Instant;
@@ -28,6 +30,7 @@ public class DiscordUserCacheService {
     private static final long STALE_MINUTES = 30;
 
     private final DiscordUserCacheRepository cacheRepository;
+    private final DiscordGuildMemberRepository memberRepository;
     private final AttendanceRepository attendanceRepository;
     private final EventRepository eventRepository;
     private final ObjectProvider<DiscordService> discordServiceProvider;
@@ -36,12 +39,14 @@ public class DiscordUserCacheService {
 
     public DiscordUserCacheService(
             DiscordUserCacheRepository cacheRepository,
+            DiscordGuildMemberRepository memberRepository,
             AttendanceRepository attendanceRepository,
             EventRepository eventRepository,
             ObjectProvider<DiscordService> discordServiceProvider,
             DiscordConfiguration discordConfiguration,
             AvatarDownloadService avatarDownloadService) {
         this.cacheRepository = cacheRepository;
+        this.memberRepository = memberRepository;
         this.attendanceRepository = attendanceRepository;
         this.eventRepository = eventRepository;
         this.discordServiceProvider = discordServiceProvider;
@@ -49,7 +54,10 @@ public class DiscordUserCacheService {
         this.avatarDownloadService = avatarDownloadService;
     }
 
+    /** Upsert global user info (username) and per-guild info (displayName, avatar). */
     public void upsertUser(String snowflake, String displayName, String username, String avatarUrl, long guildId) {
+        upsertGlobal(snowflake, username);
+
         byte[] avatarBytes = null;
         String avatarContentType = null;
         if (avatarUrl != null && !avatarUrl.isBlank()) {
@@ -60,52 +68,55 @@ public class DiscordUserCacheService {
             }
         }
 
-        Optional<DiscordUserCache> existing = cacheRepository.findById(snowflake);
-        DiscordUserCache user = existing.orElse(new DiscordUserCache(
-                snowflake, displayName, username, Instant.now(), avatarBytes, avatarContentType, new HashSet<>()));
+        DiscordGuildMember member = memberRepository
+                .findByGuildIdAndSnowflake(guildId, snowflake)
+                .orElseGet(() -> new DiscordGuildMember(guildId, snowflake, null, null, null, Instant.now()));
+        member.setDisplayName(displayName);
+        if (avatarBytes != null) {
+            member.setAvatarBytes(avatarBytes);
+            member.setAvatarContentType(avatarContentType);
+        }
+        member.setUpdatedAt(Instant.now());
+        memberRepository.save(member);
+    }
 
-        user.setDisplayName(displayName);
-        user.setUsername(username);
+    /** Register a guild membership without overwriting an existing displayName/avatar. */
+    public void registerIfMissing(String snowflake, String displayName, String username, long guildId) {
+        upsertGlobal(snowflake, username);
+
+        Optional<DiscordGuildMember> existing = memberRepository.findByGuildIdAndSnowflake(guildId, snowflake);
+        if (existing.isEmpty()) {
+            memberRepository.save(new DiscordGuildMember(guildId, snowflake, displayName, null, null, Instant.now()));
+        }
+    }
+
+    private void upsertGlobal(String snowflake, String username) {
+        DiscordUserCache user =
+                cacheRepository.findById(snowflake).orElseGet(() -> new DiscordUserCache(snowflake, null, null));
+        if (username != null && !username.equals(user.getUsername())) {
+            user.setUsername(username);
+        }
         user.setUpdatedAt(Instant.now());
-        user.setAvatarBytes(avatarBytes);
-        user.setAvatarContentType(avatarContentType);
-        user.getGuildIds().add(guildId);
-
         cacheRepository.save(user);
     }
 
-    public void registerIfMissing(String snowflake, String displayName, String username, long guildId) {
-        Optional<DiscordUserCache> existing = cacheRepository.findById(snowflake);
-        if (existing.isEmpty()) {
-            DiscordUserCache newUser =
-                    new DiscordUserCache(snowflake, displayName, username, Instant.now(), null, null, new HashSet<>());
-            newUser.getGuildIds().add(guildId);
-            cacheRepository.save(newUser);
-        } else {
-            DiscordUserCache user = existing.get();
-            boolean changed = user.getGuildIds().add(guildId);
-            if (username != null && !username.equals(user.getUsername())) {
-                user.setUsername(username);
-                changed = true;
-            }
-            if (changed) {
-                user.setUpdatedAt(Instant.now());
-                cacheRepository.save(user);
-            }
-        }
-    }
-
-    public String getDisplayName(String snowflake) {
+    /** Lookup a per-guild display name. */
+    public String getDisplayName(long guildId, String snowflake) {
         if (snowflake == null || snowflake.isBlank()) {
             return "Unknown User";
         }
-        return cacheRepository
-                .findById(snowflake)
-                .map(DiscordUserCache::getDisplayName)
-                .orElse("Unknown User (#" + snowflake.substring(Math.max(0, snowflake.length() - 4)) + ")");
+        return memberRepository
+                .findByGuildIdAndSnowflake(guildId, snowflake)
+                .map(DiscordGuildMember::getDisplayName)
+                .filter(s -> s != null && !s.isBlank())
+                .orElseGet(() -> cacheRepository
+                        .findById(snowflake)
+                        .map(DiscordUserCache::getUsername)
+                        .filter(s -> s != null && !s.isBlank())
+                        .orElse("Unknown User (#" + snowflake.substring(Math.max(0, snowflake.length() - 4)) + ")"));
     }
 
-    public Map<String, String> getDisplayNames(Collection<String> snowflakes) {
+    public Map<String, String> getDisplayNames(long guildId, Collection<String> snowflakes) {
         if (snowflakes == null || snowflakes.isEmpty()) {
             return Map.of();
         }
@@ -114,11 +125,22 @@ public class DiscordUserCacheService {
         if (unique.isEmpty()) {
             return Map.of();
         }
-        return cacheRepository.findAllBySnowflakeIn(unique).stream()
-                .collect(Collectors.toMap(DiscordUserCache::getSnowflake, DiscordUserCache::getDisplayName));
+        Map<String, String> result = memberRepository.findAllByGuildIdAndSnowflakeIn(guildId, unique).stream()
+                .filter(m -> m.getDisplayName() != null && !m.getDisplayName().isBlank())
+                .collect(Collectors.toMap(DiscordGuildMember::getSnowflake, DiscordGuildMember::getDisplayName));
+        // Fill blanks with global username so callers always get a name to render.
+        Set<String> missing = new HashSet<>(unique);
+        missing.removeAll(result.keySet());
+        if (!missing.isEmpty()) {
+            cacheRepository.findAllBySnowflakeIn(missing).stream()
+                    .filter(u -> u.getUsername() != null && !u.getUsername().isBlank())
+                    .forEach(u -> result.put(u.getSnowflake(), u.getUsername()));
+        }
+        return result;
     }
 
-    public Map<String, DiscordUserCache> getUsers(Collection<String> snowflakes) {
+    /** Per-guild members keyed by snowflake. */
+    public Map<String, DiscordGuildMember> getGuildMembers(long guildId, Collection<String> snowflakes) {
         if (snowflakes == null || snowflakes.isEmpty()) {
             return Map.of();
         }
@@ -127,13 +149,31 @@ public class DiscordUserCacheService {
         if (unique.isEmpty()) {
             return Map.of();
         }
-        return cacheRepository.findAllBySnowflakeIn(unique).stream()
-                .collect(Collectors.toMap(DiscordUserCache::getSnowflake, Function.identity()));
+        return memberRepository.findAllByGuildIdAndSnowflakeIn(guildId, unique).stream()
+                .collect(Collectors.toMap(DiscordGuildMember::getSnowflake, Function.identity()));
+    }
+
+    /** Global usernames keyed by snowflake (no per-guild context). */
+    public Map<String, String> getUsernames(Collection<String> snowflakes) {
+        if (snowflakes == null || snowflakes.isEmpty()) {
+            return Map.of();
+        }
+        Set<String> unique =
+                snowflakes.stream().filter(s -> s != null && !s.isBlank()).collect(Collectors.toSet());
+        if (unique.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, String> result = new HashMap<>();
+        cacheRepository.findAllBySnowflakeIn(unique).stream()
+                .filter(u -> u.getUsername() != null)
+                .forEach(u -> result.put(u.getSnowflake(), u.getUsername()));
+        return result;
     }
 
     @Observed(name = "discord.refresh-user-cache")
     @Scheduled(fixedDelay = 60, timeUnit = SECONDS)
     public void refreshStaleEntries() {
+        long guildId = discordConfiguration.getGuildId();
         Instant staleCutoff = Instant.now().minus(STALE_MINUTES, ChronoUnit.MINUTES);
         List<String> activeSnowflakes = new ArrayList<>(attendanceRepository.findAllDistinctSnowflakes());
         activeSnowflakes.addAll(eventRepository.findAllDistinctCreatorSnowflakes());
@@ -141,12 +181,13 @@ public class DiscordUserCacheService {
             return;
         }
 
-        Map<String, DiscordUserCache> cached = cacheRepository.findAllBySnowflakeIn(activeSnowflakes).stream()
-                .collect(Collectors.toMap(DiscordUserCache::getSnowflake, Function.identity()));
+        Map<String, DiscordGuildMember> cached =
+                memberRepository.findAllByGuildIdAndSnowflakeIn(guildId, activeSnowflakes).stream()
+                        .collect(Collectors.toMap(DiscordGuildMember::getSnowflake, Function.identity()));
 
         List<String> toRefresh = activeSnowflakes.stream()
                 .filter(s -> {
-                    DiscordUserCache entry = cached.get(s);
+                    DiscordGuildMember entry = cached.get(s);
                     return entry == null || entry.getUpdatedAt().isBefore(staleCutoff);
                 })
                 .limit(REFRESH_BATCH_SIZE)
@@ -154,14 +195,13 @@ public class DiscordUserCacheService {
 
         for (String snowflake : toRefresh) {
             try {
-                Member member = discordServiceProvider
-                        .getObject()
-                        .getMemberFromServer(discordConfiguration.getGuildId(), Long.parseLong(snowflake));
+                Member member =
+                        discordServiceProvider.getObject().getMemberFromServer(guildId, Long.parseLong(snowflake));
                 if (member != null) {
                     String displayName = DiscordUtil.getUserDisplayName(member);
                     String username = member.getUser().getName();
                     String avatarUrl = member.getEffectiveAvatar().getUrl(256);
-                    upsertUser(snowflake, displayName, username, avatarUrl, discordConfiguration.getGuildId());
+                    upsertUser(snowflake, displayName, username, avatarUrl, guildId);
                 }
             } catch (Exception e) {
                 log.debug("Failed to refresh cache for snowflake {}: {}", snowflake, e.getMessage());

--- a/backend/src/main/java/dev/tylercash/event/discord/GuildMembershipService.java
+++ b/backend/src/main/java/dev/tylercash/event/discord/GuildMembershipService.java
@@ -1,6 +1,6 @@
 package dev.tylercash.event.discord;
 
-import dev.tylercash.event.db.repository.DiscordUserCacheRepository;
+import dev.tylercash.event.db.repository.DiscordGuildMemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -10,10 +10,10 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 @RequiredArgsConstructor
 public class GuildMembershipService {
-    private final DiscordUserCacheRepository cacheRepository;
+    private final DiscordGuildMemberRepository memberRepository;
 
     public boolean isMember(String snowflake, long guildId) {
-        return cacheRepository.isUserInGuild(snowflake, guildId);
+        return memberRepository.existsByGuildIdAndSnowflake(guildId, snowflake);
     }
 
     public void assertMember(String snowflake, long guildId) {
@@ -23,6 +23,6 @@ public class GuildMembershipService {
     }
 
     public List<Long> getGuildIdsForUser(String snowflake) {
-        return cacheRepository.findGuildIdsBySnowflake(snowflake);
+        return memberRepository.findGuildIdsBySnowflake(snowflake);
     }
 }

--- a/backend/src/main/java/dev/tylercash/event/discord/model/DiscordGuildMember.java
+++ b/backend/src/main/java/dev/tylercash/event/discord/model/DiscordGuildMember.java
@@ -1,0 +1,45 @@
+package dev.tylercash.event.discord.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@Table(name = "discord_guild_member")
+@IdClass(DiscordGuildMember.PK.class)
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiscordGuildMember {
+
+    @Id
+    @Column(name = "guild_id")
+    private Long guildId;
+
+    @Id
+    private String snowflake;
+
+    private String displayName;
+
+    @Column(columnDefinition = "bytea")
+    private byte[] avatarBytes;
+
+    private String avatarContentType;
+
+    private Instant updatedAt;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PK implements Serializable {
+        private Long guildId;
+        private String snowflake;
+    }
+}

--- a/backend/src/main/java/dev/tylercash/event/discord/model/DiscordUserCache.java
+++ b/backend/src/main/java/dev/tylercash/event/discord/model/DiscordUserCache.java
@@ -1,8 +1,5 @@
 package dev.tylercash.event.discord.model;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -20,17 +17,6 @@ public class DiscordUserCache {
     @Id
     private String snowflake;
 
-    private String displayName;
     private String username;
     private Instant updatedAt;
-
-    @Column(columnDefinition = "bytea")
-    private byte[] avatarBytes;
-
-    private String avatarContentType;
-
-    @ElementCollection(fetch = jakarta.persistence.FetchType.EAGER)
-    @CollectionTable(name = "discord_user_guild", joinColumns = @jakarta.persistence.JoinColumn(name = "snowflake"))
-    @jakarta.persistence.Column(name = "guild_id")
-    private java.util.Set<Long> guildIds = new java.util.HashSet<>();
 }

--- a/backend/src/main/java/dev/tylercash/event/event/EventController.java
+++ b/backend/src/main/java/dev/tylercash/event/event/EventController.java
@@ -4,7 +4,6 @@ import dev.tylercash.event.discord.DiscordService;
 import dev.tylercash.event.discord.DiscordUserCacheService;
 import dev.tylercash.event.discord.DiscordUtil;
 import dev.tylercash.event.discord.GuildMembershipService;
-import dev.tylercash.event.discord.model.DiscordUserCache;
 import dev.tylercash.event.event.model.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -133,16 +132,17 @@ public class EventController {
                 .map(Event::getCreator)
                 .filter(s -> s != null && !s.isBlank())
                 .collect(Collectors.toSet());
-        Map<String, DiscordUserCache> userMap = discordUserCacheService.getUsers(creatorSnowflakes);
+        Map<String, String> displayNames = discordUserCacheService.getDisplayNames(guildId, creatorSnowflakes);
+        Map<String, String> usernames = discordUserCacheService.getUsernames(creatorSnowflakes);
         Map<UUID, String> categoryMap = eventService.getEventCategories(
                 events.stream().map(Event::getId).collect(Collectors.toSet()));
 
         return events.map(event -> {
-            DiscordUserCache user = userMap.get(event.getCreator());
+            String name = displayNames.get(event.getCreator());
             return new EventDto(
                     event,
-                    user != null ? user.getDisplayName() : event.getCreator(),
-                    user != null ? user.getUsername() : null,
+                    name != null ? name : event.getCreator(),
+                    usernames.get(event.getCreator()),
                     categoryMap.getOrDefault(event.getId(), "unknown"));
         });
     }
@@ -172,9 +172,10 @@ public class EventController {
             allSnowflakes.add(event.getCreator());
         }
 
-        Map<String, DiscordUserCache> userMap = discordUserCacheService.getUsers(allSnowflakes);
+        Map<String, String> displayNames = discordUserCacheService.getDisplayNames(event.getServerId(), allSnowflakes);
+        Map<String, String> usernames = discordUserCacheService.getUsernames(allSnowflakes);
         String category = eventService.getEventCategory(id);
-        return new EventDetailDto(event, completed, summary, userMap, category);
+        return new EventDetailDto(event, completed, summary, displayNames, usernames, category);
     }
 
     @Operation(summary = "RSVP to an event", description = "Record or update your attendance status for an event")
@@ -222,9 +223,10 @@ public class EventController {
         if (event.getCreator() != null && !event.getCreator().isBlank()) {
             allSnowflakes.add(event.getCreator());
         }
-        Map<String, DiscordUserCache> userMap = discordUserCacheService.getUsers(allSnowflakes);
+        Map<String, String> displayNames = discordUserCacheService.getDisplayNames(event.getServerId(), allSnowflakes);
+        Map<String, String> usernames = discordUserCacheService.getUsernames(allSnowflakes);
         String category = eventService.getEventCategory(id);
-        return new EventDetailDto(event, completed, summary, userMap, category);
+        return new EventDetailDto(event, completed, summary, displayNames, usernames, category);
     }
 
     @Operation(summary = "Cancel an event", description = "Admin-only: cancels an event and archives it")

--- a/backend/src/main/java/dev/tylercash/event/event/EventService.java
+++ b/backend/src/main/java/dev/tylercash/event/event/EventService.java
@@ -178,11 +178,11 @@ public class EventService {
             allSnowflakes.add(event.getCreator());
         }
 
-        Map<String, String> nameMap = discordUserCacheService.getDisplayNames(allSnowflakes);
+        Map<String, String> nameMap = discordUserCacheService.getDisplayNames(event.getServerId(), allSnowflakes);
 
-        event.setAccepted(toAttendeeSet(summary.accepted(), nameMap));
-        event.setDeclined(toAttendeeSet(summary.declined(), nameMap));
-        event.setMaybe(toAttendeeSet(summary.maybe(), nameMap));
+        event.setAccepted(toAttendeeSet(summary.accepted(), nameMap, event.getServerId()));
+        event.setDeclined(toAttendeeSet(summary.declined(), nameMap, event.getServerId()));
+        event.setMaybe(toAttendeeSet(summary.maybe(), nameMap, event.getServerId()));
 
         String creatorName = nameMap.get(event.getCreator());
         event.setCreatorDisplayName(creatorName != null ? creatorName : event.getCreator());
@@ -197,13 +197,13 @@ public class EventService {
         embeddingService.classifyEvent(event);
     }
 
-    private Set<Attendee> toAttendeeSet(List<AttendanceRecord> records, Map<String, String> nameMap) {
+    private Set<Attendee> toAttendeeSet(List<AttendanceRecord> records, Map<String, String> nameMap, long guildId) {
         Set<Attendee> attendees = new LinkedHashSet<>();
         for (AttendanceRecord record : records) {
             String displayName;
             if (record.getSnowflake() != null) {
                 displayName = nameMap.getOrDefault(
-                        record.getSnowflake(), discordUserCacheService.getDisplayName(record.getSnowflake()));
+                        record.getSnowflake(), discordUserCacheService.getDisplayName(guildId, record.getSnowflake()));
             } else {
                 displayName = record.getName();
             }

--- a/backend/src/main/java/dev/tylercash/event/event/model/EventDetailDto.java
+++ b/backend/src/main/java/dev/tylercash/event/event/model/EventDetailDto.java
@@ -1,6 +1,5 @@
 package dev.tylercash.event.event.model;
 
-import dev.tylercash.event.discord.model.DiscordUserCache;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -27,28 +26,33 @@ public class EventDetailDto extends EventDto {
     }
 
     public EventDetailDto(
-            Event event, boolean completed, AttendanceSummary summary, Map<String, DiscordUserCache> userMap) {
-        this(event, completed, summary, userMap, "unknown");
+            Event event,
+            boolean completed,
+            AttendanceSummary summary,
+            Map<String, String> displayNames,
+            Map<String, String> usernames) {
+        this(event, completed, summary, displayNames, usernames, "unknown");
     }
 
     public EventDetailDto(
             Event event,
             boolean completed,
             AttendanceSummary summary,
-            Map<String, DiscordUserCache> userMap,
+            Map<String, String> displayNames,
+            Map<String, String> usernames,
             String category) {
         super(event);
         this.setCategory(category == null || category.isBlank() ? "unknown" : category);
         String creator = event.getCreator();
         if (creator != null && !creator.isBlank()) {
-            DiscordUserCache user = userMap.get(creator);
-            this.setHost(user != null ? user.getDisplayName() : creator);
-            this.setHostUsername(user != null ? user.getUsername() : null);
+            String name = displayNames.get(creator);
+            this.setHost(name != null ? name : creator);
+            this.setHostUsername(usernames.get(creator));
             this.setHostAvatarUrl("/api/avatar/" + creator);
         }
-        this.accepted = toSortedRecordList(summary.accepted(), userMap);
-        this.declined = toSortedRecordList(summary.declined(), userMap);
-        this.maybe = toSortedRecordList(summary.maybe(), userMap);
+        this.accepted = toSortedRecordList(summary.accepted(), displayNames, usernames);
+        this.declined = toSortedRecordList(summary.declined(), displayNames, usernames);
+        this.maybe = toSortedRecordList(summary.maybe(), displayNames, usernames);
         this.completed = completed;
         this.hasPrivateChannel = event.getPrivateChannelId() != null;
     }
@@ -61,15 +65,15 @@ public class EventDetailDto extends EventDto {
     }
 
     private static List<AttendeeDto> toSortedRecordList(
-            List<AttendanceRecord> records, Map<String, DiscordUserCache> userMap) {
+            List<AttendanceRecord> records, Map<String, String> displayNames, Map<String, String> usernames) {
         return records.stream()
                 .map(r -> {
                     String displayName;
                     String username = null;
                     if (r.getSnowflake() != null) {
-                        DiscordUserCache user = userMap.get(r.getSnowflake());
-                        displayName = user != null ? user.getDisplayName() : r.getSnowflake();
-                        username = user != null ? user.getUsername() : null;
+                        String resolved = displayNames.get(r.getSnowflake());
+                        displayName = resolved != null ? resolved : r.getSnowflake();
+                        username = usernames.get(r.getSnowflake());
                     } else {
                         displayName = r.getName();
                     }

--- a/backend/src/main/java/dev/tylercash/event/global/SecurityController.java
+++ b/backend/src/main/java/dev/tylercash/event/global/SecurityController.java
@@ -2,6 +2,7 @@ package dev.tylercash.event.global;
 
 import dev.tylercash.event.discord.DiscordConfiguration;
 import dev.tylercash.event.discord.DiscordService;
+import dev.tylercash.event.discord.DiscordUserCacheService;
 import dev.tylercash.event.security.UserInfoDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class SecurityController {
     private final DiscordService discordService;
     private final DiscordConfiguration discordConfiguration;
+    private final DiscordUserCacheService discordUserCacheService;
 
     @Operation(summary = "Check authentication status", description = "Returns current user info if authenticated")
     @ApiResponses({
@@ -36,10 +38,9 @@ public class SecurityController {
         }
         String userSnowflake = principal.getAttribute("id");
         String username = principal.getAttribute("username");
-        String globalName = principal.getAttribute("global_name");
-        String displayName = globalName != null ? globalName : username;
-        boolean isAdmin =
-                discordService.isUserAdminOfServer(discordConfiguration.getGuildId(), Long.parseLong(userSnowflake));
+        long guildId = discordConfiguration.getGuildId();
+        String displayName = discordUserCacheService.getDisplayName(guildId, userSnowflake);
+        boolean isAdmin = discordService.isUserAdminOfServer(guildId, Long.parseLong(userSnowflake));
         return new UserInfoDto(username, displayName, userSnowflake, isAdmin, "/api/avatar/" + userSnowflake);
     }
 }

--- a/backend/src/main/java/dev/tylercash/event/rewind/RewindService.java
+++ b/backend/src/main/java/dev/tylercash/event/rewind/RewindService.java
@@ -141,7 +141,7 @@ public class RewindService {
         List<Object[]> attendeeRows = aq.getResultList();
         Set<String> attendeeSnowflakes =
                 attendeeRows.stream().map(r -> (String) r[0]).collect(Collectors.toSet());
-        Map<String, String> attendeeNames = userCacheService.getDisplayNames(attendeeSnowflakes);
+        Map<String, String> attendeeNames = userCacheService.getDisplayNames(guildId, attendeeSnowflakes);
         List<AttendeeStatDto> topAttendees = attendeeRows.stream()
                 .map(r -> {
                     String attendeeSnowflake = (String) r[0];
@@ -162,7 +162,7 @@ public class RewindService {
                 .map(r -> (String) r[0])
                 .filter(s -> s != null && !s.isBlank())
                 .collect(Collectors.toSet());
-        Map<String, String> orgNames = userCacheService.getDisplayNames(orgSnowflakes);
+        Map<String, String> orgNames = userCacheService.getDisplayNames(guildId, orgSnowflakes);
         List<AttendeeStatDto> topOrganizers = orgRows.stream()
                 .map(r -> {
                     String raw = (String) r[0];
@@ -217,7 +217,7 @@ public class RewindService {
             }
             edges.sort((a, b) -> Integer.compare(b.sharedEvents(), a.sharedEvents()));
 
-            Map<String, String> nodeNames = userCacheService.getDisplayNames(graphSnowflakes);
+            Map<String, String> nodeNames = userCacheService.getDisplayNames(guildId, graphSnowflakes);
             List<GraphNodeDto> nodes = nodeRows.stream()
                     .map(r -> {
                         String nodeSnowflake = (String) r[1];

--- a/backend/src/main/java/dev/tylercash/event/security/oauth2/CustomOAuth2UserService.java
+++ b/backend/src/main/java/dev/tylercash/event/security/oauth2/CustomOAuth2UserService.java
@@ -1,13 +1,14 @@
 package dev.tylercash.event.security.oauth2;
 
-import dev.tylercash.event.discord.AvatarDownloadService;
 import dev.tylercash.event.discord.DiscordConfiguration;
 import dev.tylercash.event.discord.DiscordService;
 import dev.tylercash.event.discord.DiscordUserCacheService;
+import dev.tylercash.event.discord.DiscordUtil;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Member;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -28,23 +29,19 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String snowflake = Objects.requireNonNull(oAuth2User.getAttribute("id"));
         String username = oAuth2User.getAttribute("username");
-        String globalName = oAuth2User.getAttribute("global_name");
         log.info("Authenticated user {}", username);
 
-        if (!discordService.isUserMemberOfServer(discordConfiguration.getGuildId(), Long.parseLong(snowflake))) {
+        long guildId = discordConfiguration.getGuildId();
+        Member member = discordService.getMemberFromServer(guildId, Long.parseLong(snowflake));
+        if (member == null) {
             log.warn("User {} not a member of the server. id: {}", username, snowflake);
-            throw new OAuth2AuthenticationException(
-                    "User not a member of discord server " + discordConfiguration.getGuildId());
+            throw new OAuth2AuthenticationException("User not a member of discord server " + guildId);
         }
 
-        String avatarHash = oAuth2User.getAttribute("avatar");
-        String avatarUrl = AvatarDownloadService.discordAvatarUrl(snowflake, avatarHash);
+        String guildDisplayName = DiscordUtil.getUserDisplayName(member);
+        String guildAvatarUrl = member.getEffectiveAvatar().getUrl(256);
         discordUserCacheService.upsertUser(
-                snowflake,
-                globalName != null ? globalName : (username != null ? username : snowflake),
-                username != null ? username : snowflake,
-                avatarUrl,
-                discordConfiguration.getGuildId());
+                snowflake, guildDisplayName, member.getUser().getName(), guildAvatarUrl, guildId);
 
         return oAuth2User;
     }

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -876,6 +876,83 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  - changeSet:
+      id: create discord_guild_member table
+      author: tyler
+      comment: >
+        Replaces discord_user_guild membership table and the per-user
+        display_name / avatar columns on discord_user_cache. Names and
+        avatars are inherently per-guild (Discord nicknames + guild
+        avatars), so they belong on a (guild_id, snowflake) row.
+      changes:
+        - createTable:
+            tableName: discord_guild_member
+            columns:
+              - column:
+                  name: guild_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: snowflake
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: display_name
+                  type: text
+              - column:
+                  name: avatar_bytes
+                  type: bytea
+              - column:
+                  name: avatar_content_type
+                  type: text
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: discord_guild_member
+            columnNames: guild_id, snowflake
+        - createIndex:
+            indexName: idx_discord_guild_member_snowflake
+            tableName: discord_guild_member
+            columns:
+              - column:
+                  name: snowflake
+
+  - changeSet:
+      id: backfill discord_guild_member from discord_user_guild
+      author: tyler
+      comment: >
+        Backfill the new per-guild member rows from existing memberships,
+        joining the per-user display_name and avatar from discord_user_cache.
+      changes:
+        - sql:
+            sql: >
+              INSERT INTO discord_guild_member (guild_id, snowflake, display_name, avatar_bytes, avatar_content_type, updated_at)
+              SELECT g.guild_id, g.snowflake, c.display_name, c.avatar_bytes, c.avatar_content_type, COALESCE(c.updated_at, NOW())
+              FROM discord_user_guild g
+              JOIN discord_user_cache c ON c.snowflake = g.snowflake
+              ON CONFLICT (guild_id, snowflake) DO NOTHING
+
+  - changeSet:
+      id: drop discord_user_guild and obsolete cache columns
+      author: tyler
+      changes:
+        - dropTable:
+            tableName: discord_user_guild
+        - dropColumn:
+            tableName: discord_user_cache
+            columns:
+              - column:
+                  name: display_name
+              - column:
+                  name: avatar_bytes
+              - column:
+                  name: avatar_content_type
+
   - include:
       file: db/changelog/contract/db.changelog-contract.yaml
 

--- a/backend/src/test/java/dev/tylercash/event/db/LiquibaseMigrationTest.java
+++ b/backend/src/test/java/dev/tylercash/event/db/LiquibaseMigrationTest.java
@@ -95,20 +95,18 @@ class LiquibaseMigrationTest {
                         .isEqualTo("111");
             }
 
-            // Verify: discord_user_cache seeded with snowflake users (not empty-snowflake guests)
+            // Verify: discord_user_cache seeded with snowflake users (not empty-snowflake guests).
+            // The seeded display_name column is dropped by a later changeset; per-guild names
+            // now live on discord_guild_member and are populated by the JDA refresher.
             try (Statement stmt = conn.createStatement()) {
-                ResultSet rs =
-                        stmt.executeQuery("SELECT snowflake, display_name FROM discord_user_cache ORDER BY snowflake");
+                ResultSet rs = stmt.executeQuery("SELECT snowflake FROM discord_user_cache ORDER BY snowflake");
                 List<String> cachedSnowflakes = new ArrayList<>();
-                List<String> cachedNames = new ArrayList<>();
                 while (rs.next()) {
                     cachedSnowflakes.add(rs.getString("snowflake"));
-                    cachedNames.add(rs.getString("display_name"));
                 }
                 assertThat(cachedSnowflakes)
                         .as("Cache should contain all non-empty snowflakes from JSON data")
                         .containsExactlyInAnyOrder("111", "222", "333", "444");
-                assertThat(cachedNames).containsExactlyInAnyOrder("Alice", "Bob", "Charlie", "Diana");
             }
 
             // Verify: attendance table populated correctly

--- a/backend/src/test/java/dev/tylercash/event/discord/AvatarControllerTest.java
+++ b/backend/src/test/java/dev/tylercash/event/discord/AvatarControllerTest.java
@@ -3,8 +3,8 @@ package dev.tylercash.event.discord;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-import dev.tylercash.event.db.repository.DiscordUserCacheRepository;
-import dev.tylercash.event.discord.model.DiscordUserCache;
+import dev.tylercash.event.db.repository.DiscordGuildMemberRepository;
+import dev.tylercash.event.discord.model.DiscordGuildMember;
 import java.time.Instant;
 import java.util.Optional;
 import net.dv8tion.jda.api.entities.Member;
@@ -22,8 +22,10 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 @ExtendWith(MockitoExtension.class)
 class AvatarControllerTest {
 
+    private static final long GUILD = 456L;
+
     @Mock
-    private DiscordUserCacheRepository repo;
+    private DiscordGuildMemberRepository repo;
 
     @Mock
     private ObjectProvider<DiscordService> discordServiceProvider;
@@ -47,9 +49,9 @@ class AvatarControllerTest {
     @Test
     void getAvatar_returns200WithBytes_whenAvatarStored() {
         byte[] bytes = new byte[] {1, 2, 3};
-        DiscordUserCache cached = new DiscordUserCache(
-                "123", "User", "username", Instant.now(), bytes, "image/webp", java.util.Set.of(456L));
-        when(repo.findById("123")).thenReturn(Optional.of(cached));
+        DiscordGuildMember cached = new DiscordGuildMember(GUILD, "123", "User", bytes, "image/webp", Instant.now());
+        when(discordConfiguration.getGuildId()).thenReturn(GUILD);
+        when(repo.findByGuildIdAndSnowflake(GUILD, "123")).thenReturn(Optional.of(cached));
         when(repo.haveSharedGuild("789", "123")).thenReturn(true);
 
         OAuth2User principal = mock(OAuth2User.class);
@@ -65,10 +67,10 @@ class AvatarControllerTest {
 
     @Test
     void getAvatar_returns302_whenAvatarMissingInCacheButFoundInJDA() {
-        when(repo.findById("123")).thenReturn(Optional.empty());
+        when(repo.findByGuildIdAndSnowflake(GUILD, "123")).thenReturn(Optional.empty());
         when(repo.haveSharedGuild("789", "123")).thenReturn(true);
         when(discordServiceProvider.getIfAvailable()).thenReturn(discordService);
-        when(discordConfiguration.getGuildId()).thenReturn(456L);
+        when(discordConfiguration.getGuildId()).thenReturn(GUILD);
 
         Member member = mock(Member.class);
         net.dv8tion.jda.api.entities.User user = mock(net.dv8tion.jda.api.entities.User.class);
@@ -78,7 +80,7 @@ class AvatarControllerTest {
         when(member.getEffectiveAvatar()).thenReturn(avatarProxy);
         when(avatarProxy.getUrl(256)).thenReturn("http://discord.cdn/avatar.png");
         when(member.getNickname()).thenReturn("Nickname");
-        when(discordService.getMemberFromServer(456L, 123L)).thenReturn(member);
+        when(discordService.getMemberFromServer(GUILD, 123L)).thenReturn(member);
 
         OAuth2User principal = mock(OAuth2User.class);
         when(principal.getAttribute("id")).thenReturn("789");
@@ -88,16 +90,16 @@ class AvatarControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
         assertThat(response.getHeaders().getLocation()).hasToString("http://discord.cdn/avatar.png");
         verify(cacheService)
-                .upsertUser(eq("123"), anyString(), eq("username"), eq("http://discord.cdn/avatar.png"), eq(456L));
+                .upsertUser(eq("123"), anyString(), eq("username"), eq("http://discord.cdn/avatar.png"), eq(GUILD));
     }
 
     @Test
     void getAvatar_returns404_whenUserNotCachedAndNotFoundInJDA() {
-        when(repo.findById("999")).thenReturn(Optional.empty());
+        when(repo.findByGuildIdAndSnowflake(GUILD, "999")).thenReturn(Optional.empty());
         when(repo.haveSharedGuild("789", "999")).thenReturn(true);
         when(discordServiceProvider.getIfAvailable()).thenReturn(discordService);
-        when(discordConfiguration.getGuildId()).thenReturn(456L);
-        when(discordService.getMemberFromServer(456L, 999L)).thenReturn(null);
+        when(discordConfiguration.getGuildId()).thenReturn(GUILD);
+        when(discordService.getMemberFromServer(GUILD, 999L)).thenReturn(null);
 
         OAuth2User principal = mock(OAuth2User.class);
         when(principal.getAttribute("id")).thenReturn("789");

--- a/backend/src/test/java/dev/tylercash/event/discord/DiscordUserCacheServiceTest.java
+++ b/backend/src/test/java/dev/tylercash/event/discord/DiscordUserCacheServiceTest.java
@@ -3,11 +3,14 @@ package dev.tylercash.event.discord;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import dev.tylercash.event.db.repository.AttendanceRepository;
+import dev.tylercash.event.db.repository.DiscordGuildMemberRepository;
 import dev.tylercash.event.db.repository.DiscordUserCacheRepository;
 import dev.tylercash.event.db.repository.EventRepository;
+import dev.tylercash.event.discord.model.DiscordGuildMember;
 import dev.tylercash.event.discord.model.DiscordUserCache;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -25,8 +28,13 @@ import org.springframework.beans.factory.ObjectProvider;
 @ExtendWith(MockitoExtension.class)
 class DiscordUserCacheServiceTest {
 
+    private static final long GUILD = 999L;
+
     @Mock
     DiscordUserCacheRepository cacheRepository;
+
+    @Mock
+    DiscordGuildMemberRepository memberRepository;
 
     @Mock
     AttendanceRepository attendanceRepository;
@@ -46,6 +54,7 @@ class DiscordUserCacheServiceTest {
     DiscordUserCacheService buildService() {
         return new DiscordUserCacheService(
                 cacheRepository,
+                memberRepository,
                 attendanceRepository,
                 eventRepository,
                 discordServiceProvider,
@@ -62,45 +71,55 @@ class DiscordUserCacheServiceTest {
                 .thenReturn(Optional.of(new AvatarDownloadService.AvatarBytes(fakeBytes, "image/webp")));
 
         buildService()
-                .upsertUser("123", "TestUser", "test_user", "https://cdn.discordapp.com/avatars/123/hash.webp", 0L);
+                .upsertUser("123", "TestUser", "test_user", "https://cdn.discordapp.com/avatars/123/hash.webp", GUILD);
 
-        ArgumentCaptor<DiscordUserCache> captor = ArgumentCaptor.forClass(DiscordUserCache.class);
-        verify(cacheRepository).save(captor.capture());
+        ArgumentCaptor<DiscordGuildMember> captor = ArgumentCaptor.forClass(DiscordGuildMember.class);
+        verify(memberRepository).save(captor.capture());
         assertThat(captor.getValue().getAvatarBytes()).isEqualTo(fakeBytes);
         assertThat(captor.getValue().getAvatarContentType()).isEqualTo("image/webp");
+        assertThat(captor.getValue().getDisplayName()).isEqualTo("TestUser");
     }
 
     @Test
-    void upsertUser_savesWithNullAvatar_whenDownloadFails() {
+    void upsertUser_keepsExistingAvatar_whenDownloadFails() {
         when(avatarDownloadService.download(any())).thenReturn(Optional.empty());
 
         buildService()
-                .upsertUser("123", "TestUser", "test_user", "https://cdn.discordapp.com/avatars/123/hash.webp", 0L);
+                .upsertUser("123", "TestUser", "test_user", "https://cdn.discordapp.com/avatars/123/hash.webp", GUILD);
 
-        ArgumentCaptor<DiscordUserCache> captor = ArgumentCaptor.forClass(DiscordUserCache.class);
-        verify(cacheRepository).save(captor.capture());
+        ArgumentCaptor<DiscordGuildMember> captor = ArgumentCaptor.forClass(DiscordGuildMember.class);
+        verify(memberRepository).save(captor.capture());
         assertThat(captor.getValue().getAvatarBytes()).isNull();
-        assertThat(captor.getValue().getAvatarContentType()).isNull();
     }
 
     @Test
     void upsertUser_savesWithNullAvatar_whenUrlIsNull() {
-        buildService().upsertUser("123", "TestUser", "test_user", null, 0L);
+        buildService().upsertUser("123", "TestUser", "test_user", null, GUILD);
 
-        ArgumentCaptor<DiscordUserCache> captor = ArgumentCaptor.forClass(DiscordUserCache.class);
-        verify(cacheRepository).save(captor.capture());
+        ArgumentCaptor<DiscordGuildMember> captor = ArgumentCaptor.forClass(DiscordGuildMember.class);
+        verify(memberRepository).save(captor.capture());
         assertThat(captor.getValue().getAvatarBytes()).isNull();
         verify(avatarDownloadService, never()).download(any());
     }
 
     @Test
     void upsertUser_savesWithNullAvatar_whenUrlIsBlank() {
-        buildService().upsertUser("123", "TestUser", "test_user", "   ", 0L);
+        buildService().upsertUser("123", "TestUser", "test_user", "   ", GUILD);
+
+        ArgumentCaptor<DiscordGuildMember> captor = ArgumentCaptor.forClass(DiscordGuildMember.class);
+        verify(memberRepository).save(captor.capture());
+        assertThat(captor.getValue().getAvatarBytes()).isNull();
+        verify(avatarDownloadService, never()).download(any());
+    }
+
+    @Test
+    void upsertUser_writesGlobalUsernameRow() {
+        buildService().upsertUser("123", "TestUser", "test_user", null, GUILD);
 
         ArgumentCaptor<DiscordUserCache> captor = ArgumentCaptor.forClass(DiscordUserCache.class);
         verify(cacheRepository).save(captor.capture());
-        assertThat(captor.getValue().getAvatarBytes()).isNull();
-        verify(avatarDownloadService, never()).download(any());
+        assertThat(captor.getValue().getUsername()).isEqualTo("test_user");
+        assertThat(captor.getValue().getSnowflake()).isEqualTo("123");
     }
 
     // ── getDisplayName ───────────────────────────────────────────────────────
@@ -109,38 +128,48 @@ class DiscordUserCacheServiceTest {
     class GetDisplayNameFallback {
 
         @Test
-        void returnsCachedName() {
-            DiscordUserCache cached = new DiscordUserCache(
-                    "111", "Alice", "alice_user", Instant.now(), null, null, java.util.Collections.emptySet());
-            when(cacheRepository.findById("111")).thenReturn(Optional.of(cached));
+        void returnsGuildNickname() {
+            DiscordGuildMember member = new DiscordGuildMember(GUILD, "111", "Alice", null, null, Instant.now());
+            when(memberRepository.findByGuildIdAndSnowflake(GUILD, "111")).thenReturn(Optional.of(member));
 
-            assertThat(buildService().getDisplayName("111")).isEqualTo("Alice");
+            assertThat(buildService().getDisplayName(GUILD, "111")).isEqualTo("Alice");
+        }
+
+        @Test
+        void fallsBackToGlobalUsername() {
+            when(memberRepository.findByGuildIdAndSnowflake(GUILD, "111")).thenReturn(Optional.empty());
+            when(cacheRepository.findById("111"))
+                    .thenReturn(Optional.of(new DiscordUserCache("111", "alice_user", Instant.now())));
+
+            assertThat(buildService().getDisplayName(GUILD, "111")).isEqualTo("alice_user");
         }
 
         @Test
         void returnsUnknownUserWithSuffix() {
+            when(memberRepository.findByGuildIdAndSnowflake(GUILD, "111223333")).thenReturn(Optional.empty());
             when(cacheRepository.findById("111223333")).thenReturn(Optional.empty());
 
-            assertThat(buildService().getDisplayName("111223333")).isEqualTo("Unknown User (#3333)");
+            assertThat(buildService().getDisplayName(GUILD, "111223333")).isEqualTo("Unknown User (#3333)");
         }
 
         @Test
         void returnsUnknownForNull() {
-            assertThat(buildService().getDisplayName(null)).isEqualTo("Unknown User");
-            verifyNoInteractions(cacheRepository);
+            assertThat(buildService().getDisplayName(GUILD, null)).isEqualTo("Unknown User");
+            verifyNoInteractions(memberRepository);
         }
 
         @Test
         void returnsUnknownForBlank() {
-            assertThat(buildService().getDisplayName("  ")).isEqualTo("Unknown User");
-            verifyNoInteractions(cacheRepository);
+            assertThat(buildService().getDisplayName(GUILD, "  ")).isEqualTo("Unknown User");
+            verifyNoInteractions(memberRepository);
         }
 
         @Test
         void handlesShortSnowflake() {
+            when(memberRepository.findByGuildIdAndSnowflake(GUILD, "12")).thenReturn(Optional.empty());
             when(cacheRepository.findById("12")).thenReturn(Optional.empty());
 
-            assertThat(buildService().getDisplayName("12")).isEqualTo("Unknown User (#12)");
+            assertThat(buildService().getDisplayName(GUILD, "12")).isEqualTo("Unknown User (#12)");
         }
     }
 
@@ -151,31 +180,31 @@ class DiscordUserCacheServiceTest {
 
         @Test
         void returnsBatchNames() {
-            List<DiscordUserCache> entries = List.of(
-                    new DiscordUserCache(
-                            "a1", "Alice", "alice_u", Instant.now(), null, null, java.util.Collections.emptySet()),
-                    new DiscordUserCache(
-                            "b2", "Bob", "bob_u", Instant.now(), null, null, java.util.Collections.emptySet()));
-            when(cacheRepository.findAllBySnowflakeIn(Set.of("a1", "b2"))).thenReturn(entries);
+            List<DiscordGuildMember> members = List.of(
+                    new DiscordGuildMember(GUILD, "a1", "Alice", null, null, Instant.now()),
+                    new DiscordGuildMember(GUILD, "b2", "Bob", null, null, Instant.now()));
+            when(memberRepository.findAllByGuildIdAndSnowflakeIn(eq(GUILD), any()))
+                    .thenReturn(members);
 
-            Map<String, String> result = buildService().getDisplayNames(Set.of("a1", "b2"));
+            Map<String, String> result = buildService().getDisplayNames(GUILD, Set.of("a1", "b2"));
 
             assertThat(result).containsEntry("a1", "Alice").containsEntry("b2", "Bob");
         }
 
         @Test
         void emptyForNull() {
-            assertThat(buildService().getDisplayNames(null)).isEmpty();
-            verifyNoInteractions(cacheRepository);
+            assertThat(buildService().getDisplayNames(GUILD, null)).isEmpty();
+            verifyNoInteractions(memberRepository);
         }
 
         @Test
         void filtersNullAndBlank() {
-            List<DiscordUserCache> entries = List.of(new DiscordUserCache(
-                    "valid", "Valid", "valid_u", Instant.now(), null, null, java.util.Collections.emptySet()));
-            when(cacheRepository.findAllBySnowflakeIn(Set.of("valid"))).thenReturn(entries);
+            List<DiscordGuildMember> members =
+                    List.of(new DiscordGuildMember(GUILD, "valid", "Valid", null, null, Instant.now()));
+            when(memberRepository.findAllByGuildIdAndSnowflakeIn(eq(GUILD), eq(Set.of("valid"))))
+                    .thenReturn(members);
 
-            Map<String, String> result = buildService().getDisplayNames(Arrays.asList("valid", null, "  "));
+            Map<String, String> result = buildService().getDisplayNames(GUILD, Arrays.asList("valid", null, "  "));
 
             assertThat(result).containsOnlyKeys("valid");
         }
@@ -188,22 +217,16 @@ class DiscordUserCacheServiceTest {
 
         @Test
         void refreshesStaleEntries() {
-            long guildId = 999L;
             String snowflake = "123456789012345678";
             long snowflakeLong = Long.parseLong(snowflake);
-            when(discordConfiguration.getGuildId()).thenReturn(guildId);
+            when(discordConfiguration.getGuildId()).thenReturn(GUILD);
             when(attendanceRepository.findAllDistinctSnowflakes()).thenReturn(List.of(snowflake));
             when(eventRepository.findAllDistinctCreatorSnowflakes()).thenReturn(List.of());
 
-            DiscordUserCache stale = new DiscordUserCache(
-                    snowflake,
-                    "OldName",
-                    "old_u",
-                    Instant.now().minus(60, ChronoUnit.MINUTES),
-                    null,
-                    null,
-                    new java.util.HashSet<>(List.of(guildId)));
-            when(cacheRepository.findAllBySnowflakeIn(List.of(snowflake))).thenReturn(List.of(stale));
+            DiscordGuildMember stale = new DiscordGuildMember(
+                    GUILD, snowflake, "OldName", null, null, Instant.now().minus(60, ChronoUnit.MINUTES));
+            when(memberRepository.findAllByGuildIdAndSnowflakeIn(eq(GUILD), any()))
+                    .thenReturn(List.of(stale));
 
             DiscordService discordService = mock(DiscordService.class);
             Member member = mock(Member.class);
@@ -211,7 +234,7 @@ class DiscordUserCacheServiceTest {
             when(member.getUser()).thenReturn(jdaUser);
             when(jdaUser.getName()).thenReturn("new_u");
             when(discordServiceProvider.getObject()).thenReturn(discordService);
-            when(discordService.getMemberFromServer(guildId, snowflakeLong)).thenReturn(member);
+            when(discordService.getMemberFromServer(GUILD, snowflakeLong)).thenReturn(member);
             when(member.getNickname()).thenReturn("NewName");
             when(member.getEffectiveName()).thenReturn("NewName");
             ImageProxy avatarProxy = mock(ImageProxy.class);
@@ -221,7 +244,7 @@ class DiscordUserCacheServiceTest {
 
             buildService().refreshStaleEntries();
 
-            verify(cacheRepository).save(any(DiscordUserCache.class));
+            verify(memberRepository).save(any(DiscordGuildMember.class));
         }
 
         @Test
@@ -231,26 +254,21 @@ class DiscordUserCacheServiceTest {
 
             buildService().refreshStaleEntries();
 
+            verifyNoInteractions(memberRepository);
             verifyNoInteractions(cacheRepository);
         }
 
         @Test
         void handlesApiFailure() {
-            long guildId = 999L;
             String snowflake = "987654321098765432";
-            when(discordConfiguration.getGuildId()).thenReturn(guildId);
+            when(discordConfiguration.getGuildId()).thenReturn(GUILD);
             when(attendanceRepository.findAllDistinctSnowflakes()).thenReturn(List.of(snowflake));
             when(eventRepository.findAllDistinctCreatorSnowflakes()).thenReturn(List.of());
 
-            DiscordUserCache stale = new DiscordUserCache(
-                    snowflake,
-                    "OldName",
-                    "old_u",
-                    Instant.now().minus(60, ChronoUnit.MINUTES),
-                    null,
-                    null,
-                    java.util.Collections.emptySet());
-            when(cacheRepository.findAllBySnowflakeIn(List.of(snowflake))).thenReturn(List.of(stale));
+            DiscordGuildMember stale = new DiscordGuildMember(
+                    GUILD, snowflake, "OldName", null, null, Instant.now().minus(60, ChronoUnit.MINUTES));
+            when(memberRepository.findAllByGuildIdAndSnowflakeIn(eq(GUILD), any()))
+                    .thenReturn(List.of(stale));
 
             DiscordService discordService = mock(DiscordService.class);
             when(discordServiceProvider.getObject()).thenReturn(discordService);
@@ -259,7 +277,7 @@ class DiscordUserCacheServiceTest {
 
             buildService().refreshStaleEntries();
 
-            verify(cacheRepository, never()).save(any());
+            verify(memberRepository, never()).save(any());
         }
     }
 }

--- a/backend/src/test/java/dev/tylercash/event/discord/DiscordUserCacheTest.java
+++ b/backend/src/test/java/dev/tylercash/event/discord/DiscordUserCacheTest.java
@@ -2,7 +2,7 @@ package dev.tylercash.event.discord;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.tylercash.event.discord.model.DiscordUserCache;
+import dev.tylercash.event.discord.model.DiscordGuildMember;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
@@ -10,18 +10,16 @@ class DiscordUserCacheTest {
 
     @Test
     void avatarFieldsDefaultToNull() {
-        DiscordUserCache cache = new DiscordUserCache(
-                "123", "TestUser", "testuser", Instant.now(), null, null, java.util.Collections.emptySet());
-        assertThat(cache.getAvatarBytes()).isNull();
-        assertThat(cache.getAvatarContentType()).isNull();
+        DiscordGuildMember member = new DiscordGuildMember(1L, "123", "TestUser", null, null, Instant.now());
+        assertThat(member.getAvatarBytes()).isNull();
+        assertThat(member.getAvatarContentType()).isNull();
     }
 
     @Test
     void avatarFieldsCanBeSet() {
         byte[] bytes = new byte[] {1, 2, 3};
-        DiscordUserCache cache = new DiscordUserCache(
-                "123", "TestUser", "testuser", Instant.now(), bytes, "image/webp", java.util.Collections.emptySet());
-        assertThat(cache.getAvatarBytes()).isEqualTo(bytes);
-        assertThat(cache.getAvatarContentType()).isEqualTo("image/webp");
+        DiscordGuildMember member = new DiscordGuildMember(1L, "123", "TestUser", bytes, "image/webp", Instant.now());
+        assertThat(member.getAvatarBytes()).isEqualTo(bytes);
+        assertThat(member.getAvatarContentType()).isEqualTo("image/webp");
     }
 }

--- a/backend/src/test/java/dev/tylercash/event/event/EventControllerTest.java
+++ b/backend/src/test/java/dev/tylercash/event/event/EventControllerTest.java
@@ -3,19 +3,18 @@ package dev.tylercash.event.event;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import dev.tylercash.event.discord.DiscordService;
 import dev.tylercash.event.discord.DiscordUserCacheService;
 import dev.tylercash.event.discord.GuildMembershipService;
-import dev.tylercash.event.discord.model.DiscordUserCache;
 import dev.tylercash.event.event.model.AttendanceStatus;
 import dev.tylercash.event.event.model.AttendanceSummary;
 import dev.tylercash.event.event.model.Event;
 import dev.tylercash.event.event.model.EventDetailDto;
 import dev.tylercash.event.event.model.EventDto;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -356,19 +355,17 @@ class EventControllerTest {
         UUID eventId = UUID.randomUUID();
         Event event = buildFullEvent(eventId, DISCORD_ID);
         AttendanceSummary summary = new AttendanceSummary(List.of(), List.of(), List.of());
-        DiscordUserCache hostUser =
-                new DiscordUserCache(DISCORD_ID, "Host Name", "host_user", Instant.now(), null, null, Set.of(GUILD_ID));
-
         when(ctx.eventService.getEvent(eventId)).thenReturn(event);
         when(ctx.eventService.isCompleted(event)).thenReturn(false);
         when(ctx.attendanceService.getCurrentAttendance(eventId)).thenReturn(summary);
-        when(ctx.discordUserCacheService.getUsers(any())).thenReturn(Map.of(DISCORD_ID, hostUser));
+        when(ctx.discordUserCacheService.getDisplayNames(anyLong(), any())).thenReturn(Map.of(DISCORD_ID, "Host Name"));
+        when(ctx.discordUserCacheService.getUsernames(any())).thenReturn(Map.of(DISCORD_ID, "host_user"));
 
         ctx.controller.getEvent(eventId, ctx.principal);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Set<String>> snowflakesCaptor = ArgumentCaptor.forClass(Set.class);
-        verify(ctx.discordUserCacheService).getUsers(snowflakesCaptor.capture());
+        verify(ctx.discordUserCacheService).getDisplayNames(anyLong(), snowflakesCaptor.capture());
         assertThat(snowflakesCaptor.getValue()).contains(DISCORD_ID);
     }
 
@@ -378,13 +375,12 @@ class EventControllerTest {
         UUID eventId = UUID.randomUUID();
         Event event = buildFullEvent(eventId, DISCORD_ID);
         AttendanceSummary summary = new AttendanceSummary(List.of(), List.of(), List.of());
-        DiscordUserCache hostUser =
-                new DiscordUserCache(DISCORD_ID, "Host Name", "host_user", Instant.now(), null, null, Set.of(GUILD_ID));
 
         when(ctx.eventService.getEvent(eventId)).thenReturn(event);
         when(ctx.eventService.isCompleted(event)).thenReturn(false);
         when(ctx.attendanceService.getCurrentAttendance(eventId)).thenReturn(summary);
-        when(ctx.discordUserCacheService.getUsers(any())).thenReturn(Map.of(DISCORD_ID, hostUser));
+        when(ctx.discordUserCacheService.getDisplayNames(anyLong(), any())).thenReturn(Map.of(DISCORD_ID, "Host Name"));
+        when(ctx.discordUserCacheService.getUsernames(any())).thenReturn(Map.of(DISCORD_ID, "host_user"));
 
         EventDetailDto result = ctx.controller.getEvent(eventId, ctx.principal);
 
@@ -433,9 +429,9 @@ class EventControllerTest {
 
         Page<Event> eventPage = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
         when(ctx.eventService.getActiveEvents(any(), eq(GUILD_ID))).thenReturn(eventPage);
-        DiscordUserCache user = new DiscordUserCache(
-                DISCORD_ID, "Resolved Name", "username", Instant.now(), null, null, Set.of(GUILD_ID));
-        when(ctx.discordUserCacheService.getUsers(Set.of(DISCORD_ID))).thenReturn(Map.of(DISCORD_ID, user));
+        when(ctx.discordUserCacheService.getDisplayNames(eq(GUILD_ID), eq(Set.of(DISCORD_ID))))
+                .thenReturn(Map.of(DISCORD_ID, "Resolved Name"));
+        when(ctx.discordUserCacheService.getUsernames(Set.of(DISCORD_ID))).thenReturn(Map.of(DISCORD_ID, "username"));
 
         Page<EventDto> result = ctx.controller.getEvents(GUILD_ID, PageRequest.of(0, 10), ctx.principal);
 
@@ -460,7 +456,9 @@ class EventControllerTest {
 
         Page<Event> eventPage = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
         when(ctx.eventService.getActiveEvents(any(), eq(GUILD_ID))).thenReturn(eventPage);
-        when(ctx.discordUserCacheService.getUsers(Set.of(DISCORD_ID))).thenReturn(Map.of());
+        when(ctx.discordUserCacheService.getDisplayNames(eq(GUILD_ID), eq(Set.of(DISCORD_ID))))
+                .thenReturn(Map.of());
+        when(ctx.discordUserCacheService.getUsernames(Set.of(DISCORD_ID))).thenReturn(Map.of());
 
         Page<EventDto> result = ctx.controller.getEvents(GUILD_ID, PageRequest.of(0, 10), ctx.principal);
 

--- a/backend/src/test/java/dev/tylercash/event/event/EventServiceIntegrationTest.java
+++ b/backend/src/test/java/dev/tylercash/event/event/EventServiceIntegrationTest.java
@@ -194,11 +194,11 @@ class EventServiceIntegrationTest {
     void discordUserCache_upsertAndLookup() {
         discordUserCacheService.upsertUser("cache1", "OriginalName", "user1", null, 0L);
 
-        assertThat(discordUserCacheService.getDisplayName("cache1")).isEqualTo("OriginalName");
+        assertThat(discordUserCacheService.getDisplayName(0L, "cache1")).isEqualTo("OriginalName");
 
         // Upsert with new name
         discordUserCacheService.upsertUser("cache1", "UpdatedName", "user1", null, 0L);
-        assertThat(discordUserCacheService.getDisplayName("cache1")).isEqualTo("UpdatedName");
+        assertThat(discordUserCacheService.getDisplayName(0L, "cache1")).isEqualTo("UpdatedName");
     }
 
     @Test
@@ -207,7 +207,7 @@ class EventServiceIntegrationTest {
         discordUserCacheService.upsertUser("batch1", "Alice", "alice_user", null, 0L);
         discordUserCacheService.upsertUser("batch2", "Bob", "bob_user", null, 0L);
 
-        Map<String, String> names = discordUserCacheService.getDisplayNames(List.of("batch1", "batch2", "missing"));
+        Map<String, String> names = discordUserCacheService.getDisplayNames(0L, List.of("batch1", "batch2", "missing"));
 
         assertThat(names).hasSize(2).containsEntry("batch1", "Alice").containsEntry("batch2", "Bob");
     }

--- a/backend/src/test/java/dev/tylercash/event/event/EventServiceTest.java
+++ b/backend/src/test/java/dev/tylercash/event/event/EventServiceTest.java
@@ -1,6 +1,8 @@
 package dev.tylercash.event.event;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 import dev.tylercash.event.db.repository.EventRepository;
@@ -59,7 +61,7 @@ class EventServiceTest {
         when(eventRepository.findById(id)).thenReturn(Optional.of(event));
         when(attendanceService.getCurrentAttendance(id))
                 .thenReturn(new AttendanceSummary(List.of(), List.of(), List.of()));
-        when(cacheService.getDisplayNames(any())).thenReturn(Map.of());
+        when(cacheService.getDisplayNames(anyLong(), any())).thenReturn(Map.of());
 
         service.removeAttendee(id, "12345", null);
 
@@ -80,7 +82,7 @@ class EventServiceTest {
         when(eventRepository.findById(id)).thenReturn(Optional.of(event));
         when(attendanceService.getCurrentAttendance(id))
                 .thenReturn(new AttendanceSummary(List.of(), List.of(), List.of()));
-        when(cacheService.getDisplayNames(any())).thenReturn(Map.of());
+        when(cacheService.getDisplayNames(anyLong(), any())).thenReturn(Map.of());
 
         service.removeAttendee(id, null, "[+1] Dave");
 

--- a/backend/src/test/java/dev/tylercash/event/event/model/EventDetailDtoTest.java
+++ b/backend/src/test/java/dev/tylercash/event/event/model/EventDetailDtoTest.java
@@ -2,10 +2,8 @@ package dev.tylercash.event.event.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.tylercash.event.discord.model.DiscordUserCache;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -14,10 +12,6 @@ class EventDetailDtoTest {
 
     private static Event buildEvent() {
         return new Event(0L, 0L, 0L, "Test Event", "creator", ZonedDateTime.now(), "description");
-    }
-
-    private static DiscordUserCache buildCache(String snowflake, String displayName, String username) {
-        return new DiscordUserCache(snowflake, displayName, username, Instant.now(), null, null, new HashSet<>());
     }
 
     @Test
@@ -51,7 +45,6 @@ class EventDetailDtoTest {
         Attendee first = Attendee.createDiscordAttendee("aaa", "First");
         Thread.sleep(5);
         Attendee second = Attendee.createDiscordAttendee("bbb", "Second");
-        // Add in reverse order to ensure sorting is applied
         event.getAccepted().add(second);
         event.getAccepted().add(first);
 
@@ -121,60 +114,64 @@ class EventDetailDtoTest {
     }
 
     @Test
-    void fourArgConstructor_hostResolvedFromNameMap() {
+    void fiveArgConstructor_hostResolvedFromNameMap() {
         Event event = buildEvent();
         event.setCreator("creator-snowflake");
         AttendanceSummary summary = new AttendanceSummary(List.of(), List.of(), List.of());
-        Map<String, DiscordUserCache> nameMap =
-                Map.of("creator-snowflake", buildCache("creator-snowflake", "Host Display Name", "host_username"));
+        Map<String, String> displayNames = Map.of("creator-snowflake", "Host Display Name");
+        Map<String, String> usernames = Map.of("creator-snowflake", "host_username");
 
-        EventDetailDto dto = new EventDetailDto(event, false, summary, nameMap);
+        EventDetailDto dto = new EventDetailDto(event, false, summary, displayNames, usernames);
 
         assertThat(dto.getHost()).isEqualTo("Host Display Name");
         assertThat(dto.getHostUsername()).isEqualTo("host_username");
     }
 
     @Test
-    void fourArgConstructor_hostAvatarUrlUsesCreatorSnowflake() {
+    void fiveArgConstructor_hostAvatarUrlUsesCreatorSnowflake() {
         Event event = buildEvent();
         event.setCreator("creator-snowflake");
         AttendanceSummary summary = new AttendanceSummary(List.of(), List.of(), List.of());
-        Map<String, DiscordUserCache> nameMap =
-                Map.of("creator-snowflake", buildCache("creator-snowflake", "Host Display Name", "host_username"));
+        Map<String, String> displayNames = Map.of("creator-snowflake", "Host Display Name");
+        Map<String, String> usernames = Map.of("creator-snowflake", "host_username");
 
-        EventDetailDto dto = new EventDetailDto(event, false, summary, nameMap);
+        EventDetailDto dto = new EventDetailDto(event, false, summary, displayNames, usernames);
 
         assertThat(dto.getHostAvatarUrl()).isEqualTo("/api/avatar/creator-snowflake");
     }
 
     @Test
-    void fourArgConstructor_hostFallsBackToSnowflakeWhenNotInMap() {
+    void fiveArgConstructor_hostFallsBackToSnowflakeWhenNotInMap() {
         Event event = buildEvent();
         event.setCreator("creator-snowflake");
         AttendanceSummary summary = new AttendanceSummary(List.of(), List.of(), List.of());
-        Map<String, DiscordUserCache> nameMap = Map.of();
 
-        EventDetailDto dto = new EventDetailDto(event, false, summary, nameMap);
+        EventDetailDto dto = new EventDetailDto(event, false, summary, Map.of(), Map.of());
 
         assertThat(dto.getHost()).isEqualTo("creator-snowflake");
         assertThat(dto.getHostAvatarUrl()).isEqualTo("/api/avatar/creator-snowflake");
     }
 
     @Test
-    void fourArgConstructor_attendanceRecordsPopulatedFromSummary() {
+    void fiveArgConstructor_attendanceRecordsPopulatedFromSummary() {
         Event event = buildEvent();
         event.setCreator("creator-snowflake");
         AttendanceRecord accepted = buildRecord("user-1", "Alice");
         AttendanceRecord declined = buildRecord("user-2", "Bob");
         AttendanceRecord maybe = buildRecord("user-3", "Charlie");
         AttendanceSummary summary = new AttendanceSummary(List.of(accepted), List.of(declined), List.of(maybe));
-        Map<String, DiscordUserCache> nameMap = Map.of(
-                "creator-snowflake", buildCache("creator-snowflake", "Host", "host_user"),
-                "user-1", buildCache("user-1", "Alice Resolved", "alice_user"),
-                "user-2", buildCache("user-2", "Bob Resolved", "bob_user"),
-                "user-3", buildCache("user-3", "Charlie Resolved", "charlie_user"));
+        Map<String, String> displayNames = Map.of(
+                "creator-snowflake", "Host",
+                "user-1", "Alice Resolved",
+                "user-2", "Bob Resolved",
+                "user-3", "Charlie Resolved");
+        Map<String, String> usernames = Map.of(
+                "creator-snowflake", "host_user",
+                "user-1", "alice_user",
+                "user-2", "bob_user",
+                "user-3", "charlie_user");
 
-        EventDetailDto dto = new EventDetailDto(event, false, summary, nameMap);
+        EventDetailDto dto = new EventDetailDto(event, false, summary, displayNames, usernames);
 
         assertThat(dto.getAccepted()).hasSize(1);
         assertThat(dto.getAccepted().get(0).getName()).isEqualTo("Alice Resolved");

--- a/backend/src/test/java/dev/tylercash/event/global/SecurityControllerTest.java
+++ b/backend/src/test/java/dev/tylercash/event/global/SecurityControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import dev.tylercash.event.discord.DiscordConfiguration;
 import dev.tylercash.event.discord.DiscordService;
+import dev.tylercash.event.discord.DiscordUserCacheService;
 import dev.tylercash.event.security.UserInfoDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,7 @@ class SecurityControllerTest {
     void isLoggedIn_returnsUserInfoDtoWithAdminTrue_whenUserHasAdminRole() {
         DiscordService discordService = mock(DiscordService.class);
         DiscordConfiguration config = mock(DiscordConfiguration.class);
+        DiscordUserCacheService cacheService = mock(DiscordUserCacheService.class);
         OAuth2User principal = mock(OAuth2User.class);
 
         when(config.getGuildId()).thenReturn(GUILD_ID);
@@ -32,11 +34,13 @@ class SecurityControllerTest {
         when(principal.getAttribute("username")).thenReturn(USERNAME);
         when(discordService.isUserAdminOfServer(GUILD_ID, Long.parseLong(DISCORD_ID)))
                 .thenReturn(true);
+        when(cacheService.getDisplayName(GUILD_ID, DISCORD_ID)).thenReturn("Server Nickname");
 
-        SecurityController controller = new SecurityController(discordService, config);
+        SecurityController controller = new SecurityController(discordService, config, cacheService);
         UserInfoDto result = controller.isLoggedIn(principal);
 
         assertThat(result.getUsername()).isEqualTo(USERNAME);
+        assertThat(result.getDisplayName()).isEqualTo("Server Nickname");
         assertThat(result.getDiscordId()).isEqualTo(DISCORD_ID);
         assertThat(result.isAdmin()).isTrue();
         assertThat(result.getAvatarUrl()).isEqualTo("/api/avatar/" + DISCORD_ID);
@@ -46,6 +50,7 @@ class SecurityControllerTest {
     void isLoggedIn_returnsUserInfoDtoWithAdminFalse_whenUserLacksAdminRole() {
         DiscordService discordService = mock(DiscordService.class);
         DiscordConfiguration config = mock(DiscordConfiguration.class);
+        DiscordUserCacheService cacheService = mock(DiscordUserCacheService.class);
         OAuth2User principal = mock(OAuth2User.class);
 
         when(config.getGuildId()).thenReturn(GUILD_ID);
@@ -53,8 +58,9 @@ class SecurityControllerTest {
         when(principal.getAttribute("username")).thenReturn(USERNAME);
         when(discordService.isUserAdminOfServer(GUILD_ID, Long.parseLong(DISCORD_ID)))
                 .thenReturn(false);
+        when(cacheService.getDisplayName(GUILD_ID, DISCORD_ID)).thenReturn("Nickname");
 
-        SecurityController controller = new SecurityController(discordService, config);
+        SecurityController controller = new SecurityController(discordService, config, cacheService);
         UserInfoDto result = controller.isLoggedIn(principal);
 
         assertThat(result.isAdmin()).isFalse();
@@ -67,8 +73,9 @@ class SecurityControllerTest {
     void isLoggedIn_throwsUnauthorized_whenPrincipalIsNull() {
         DiscordService discordService = mock(DiscordService.class);
         DiscordConfiguration config = mock(DiscordConfiguration.class);
+        DiscordUserCacheService cacheService = mock(DiscordUserCacheService.class);
 
-        SecurityController controller = new SecurityController(discordService, config);
+        SecurityController controller = new SecurityController(discordService, config, cacheService);
 
         assertThatThrownBy(() -> controller.isLoggedIn(null))
                 .isInstanceOf(ResponseStatusException.class)
@@ -84,6 +91,7 @@ class SecurityControllerTest {
     void isLoggedIn_usesGuildIdFromConfiguration() {
         DiscordService discordService = mock(DiscordService.class);
         DiscordConfiguration config = mock(DiscordConfiguration.class);
+        DiscordUserCacheService cacheService = mock(DiscordUserCacheService.class);
         OAuth2User principal = mock(OAuth2User.class);
 
         long specificGuildId = 999888777L;
@@ -92,9 +100,10 @@ class SecurityControllerTest {
         when(principal.getAttribute("username")).thenReturn(USERNAME);
         when(discordService.isUserAdminOfServer(eq(specificGuildId), anyLong())).thenReturn(false);
 
-        SecurityController controller = new SecurityController(discordService, config);
+        SecurityController controller = new SecurityController(discordService, config, cacheService);
         controller.isLoggedIn(principal);
 
         verify(discordService).isUserAdminOfServer(specificGuildId, Long.parseLong(DISCORD_ID));
+        verify(cacheService).getDisplayName(specificGuildId, DISCORD_ID);
     }
 }

--- a/backend/src/test/java/dev/tylercash/event/rewind/RewindRbacIntegrationTest.java
+++ b/backend/src/test/java/dev/tylercash/event/rewind/RewindRbacIntegrationTest.java
@@ -110,7 +110,7 @@ class RewindRbacIntegrationTest {
         jdbc.execute("DELETE FROM attendance");
         jdbc.execute("DELETE FROM event_category");
         jdbc.execute("DELETE FROM event");
-        jdbc.execute("DELETE FROM discord_user_guild");
+        jdbc.execute("DELETE FROM discord_guild_member");
         jdbc.execute("DELETE FROM discord_user_cache");
         var rewindCache = cacheManager.getCache("rewind");
         if (rewindCache != null) rewindCache.clear();

--- a/backend/src/test/java/dev/tylercash/event/security/AuthorizationFuzzIntegrationTest.java
+++ b/backend/src/test/java/dev/tylercash/event/security/AuthorizationFuzzIntegrationTest.java
@@ -154,7 +154,7 @@ class AuthorizationFuzzIntegrationTest {
         jdbc.execute("DELETE FROM attendance");
         jdbc.execute("DELETE FROM event_category");
         jdbc.execute("DELETE FROM event");
-        jdbc.execute("DELETE FROM discord_user_guild");
+        jdbc.execute("DELETE FROM discord_guild_member");
         jdbc.execute("DELETE FROM discord_user_cache");
 
         discordUserCacheService.registerIfMissing(USER_IN_GUILD_1, "Fuzzy A", "fuzzya", GUILD_1);

--- a/backend/src/test/java/dev/tylercash/event/security/CsrfHardeningIntegrationTest.java
+++ b/backend/src/test/java/dev/tylercash/event/security/CsrfHardeningIntegrationTest.java
@@ -89,7 +89,7 @@ class CsrfHardeningIntegrationTest {
 
     @BeforeEach
     void seed() {
-        jdbc.execute("DELETE FROM discord_user_guild");
+        jdbc.execute("DELETE FROM discord_guild_member");
         jdbc.execute("DELETE FROM discord_user_cache");
         discordUserCacheService.registerIfMissing(USER_IN_GUILD_1, "Csrf A", "csrfa", GUILD_1);
     }

--- a/backend/src/test/java/dev/tylercash/event/security/ResponseSerializationTest.java
+++ b/backend/src/test/java/dev/tylercash/event/security/ResponseSerializationTest.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dev.tylercash.event.discord.GuildDto;
 import dev.tylercash.event.discord.GuildSettingsDto;
-import dev.tylercash.event.discord.model.DiscordUserCache;
 import dev.tylercash.event.event.model.AttendanceRecord;
 import dev.tylercash.event.event.model.AttendanceStatus;
 import dev.tylercash.event.event.model.AttendanceSummary;
@@ -100,15 +99,7 @@ class ResponseSerializationTest {
         rec.setStatus(AttendanceStatus.ACCEPTED);
         rec.setRecordedAt(Instant.parse("2099-01-01T00:00:00Z"));
         AttendanceSummary summary = new AttendanceSummary(List.of(rec), List.of(), List.of());
-        DiscordUserCache user = new DiscordUserCache(
-                "111",
-                "Alice",
-                "alice",
-                Instant.parse("2099-01-01T00:00:00Z"),
-                new byte[] {1, 2, 3},
-                "image/webp",
-                new HashSet<>(Set.of(311L)));
-        out.add(new EventDetailDto(event, true, summary, Map.of("111", user), "social"));
+        out.add(new EventDetailDto(event, true, summary, Map.of("111", "Alice"), Map.of("111", "alice"), "social"));
 
         out.add(new AttendeeDto(a));
 


### PR DESCRIPTION
…h global Discord name

OAuth2 login was writing the user's global Discord name into a single display_name column, clobbering the guild nickname populated by the JDA refresher. Display names and avatars are inherently per-guild on Discord, so the data model now matches: a new discord_guild_member table keyed on (guild_id, snowflake) holds nickname + avatar, and discord_user_cache keeps only the global username.

All read sites (events, rewind, avatar, /auth/is-logged-in) now resolve names by (guildId, snowflake), so the UI shows the user's name as it appears in the selected guild.