### PR TITLE
test(frontend): render harness for top-level page components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/d3": "^7.4.3",
@@ -38,6 +39,13 @@
         "typescript": "^5.6.2",
         "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1767,6 +1775,33 @@
       "dependencies": {
         "dequal": "^2.0.3"
       }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -3760,6 +3795,13 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5632,6 +5674,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -6680,6 +6732,16 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -7649,6 +7711,20 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8375,6 +8451,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/d3": "^7.4.3",

--- a/frontend/src/__tests__/render/EventDetail.test.tsx
+++ b/frontend/src/__tests__/render/EventDetail.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, trapConsoleError } from "../setup/render";
+import { EventDetail } from "@/components/event/EventDetail";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/events/1",
+}));
+
+// MSW handlers in src/mocks/handlers.ts service the SWR fetches.
+
+describe("EventDetail (render harness)", () => {
+  it("mounts without crashing and shows the fixture event title", async () => {
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<EventDetail id="1" />);
+
+      // store.events[0].name is "pub quiz at the glass barrel"
+      await screen.findByText(/pub quiz at the glass barrel/i, undefined, { timeout: 3000 });
+    } finally {
+      restore();
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/render/EventsFeed.test.tsx
+++ b/frontend/src/__tests__/render/EventsFeed.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, trapConsoleError } from "../setup/render";
+import { EventsFeed } from "@/components/feed/EventsFeed";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/",
+}));
+
+// MSW handlers in src/mocks/handlers.ts service the SWR fetches.
+
+describe("EventsFeed (render harness)", () => {
+  it("mounts without crashing and shows a fixture event", async () => {
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<EventsFeed />);
+
+      // "pub quiz at the glass barrel" is store.events[0].name in fixtures.ts
+      await screen.findByText(/pub quiz at the glass barrel/i, undefined, { timeout: 3000 });
+    } finally {
+      restore();
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/render/GalleryFeed.test.tsx
+++ b/frontend/src/__tests__/render/GalleryFeed.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, trapConsoleError } from "../setup/render";
+import { GalleryFeed } from "@/components/gallery/GalleryFeed";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/gallery",
+}));
+
+// MSW handlers in src/mocks/handlers.ts service the SWR fetches.
+
+describe("GalleryFeed (render harness)", () => {
+  it("mounts without crashing and shows a fixture album name", async () => {
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<GalleryFeed />);
+
+      // galleryAlbums[0].eventName mirrors store.events[0].name = "pub quiz at the glass barrel"
+      await screen.findByText(/pub quiz at the glass barrel/i, undefined, { timeout: 3000 });
+    } finally {
+      restore();
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/render/GuildSettingsForm.test.tsx
+++ b/frontend/src/__tests__/render/GuildSettingsForm.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, trapConsoleError } from "../setup/render";
+import { GuildSettingsForm } from "@/components/guild/GuildSettingsForm";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "mockguild-1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/guild/mockguild-1/settings",
+}));
+
+// MSW handlers in src/mocks/handlers.ts service the SWR fetches.
+
+describe("GuildSettingsForm (render harness)", () => {
+  it("mounts without crashing and shows the primary location label", async () => {
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<GuildSettingsForm guildId="mockguild-1" />);
+
+      // GuildSettingsForm renders <Field label="primary location"> once settings load
+      await screen.findByText(/primary location/i, undefined, { timeout: 3000 });
+    } finally {
+      restore();
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/render/Login.test.tsx
+++ b/frontend/src/__tests__/render/Login.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, trapConsoleError } from "../setup/render";
+import { LoginHero } from "@/components/login/LoginHero";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/login",
+}));
+
+// MSW handlers in src/mocks/handlers.ts service the SWR fetches.
+
+describe("LoginHero (render harness)", () => {
+  it("mounts without crashing and shows the Discord CTA button", async () => {
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<LoginHero />);
+
+      // LoginHero renders "continue with Discord" as the primary CTA button
+      await screen.findByText(/continue with Discord/i, undefined, { timeout: 3000 });
+    } finally {
+      restore();
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/render/Rewind.test.tsx
+++ b/frontend/src/__tests__/render/Rewind.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, trapConsoleError } from "../setup/render";
+import { Rewind } from "@/components/rewind/Rewind";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/rewind",
+}));
+
+// jsdom doesn't implement IntersectionObserver — stub it so SocialGraph.tsx
+// doesn't throw when it wires up its scroll-in-view animation.
+beforeAll(() => {
+  if (typeof globalThis.IntersectionObserver === "undefined") {
+    globalThis.IntersectionObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof IntersectionObserver;
+  }
+});
+
+// MSW handlers in src/mocks/handlers.ts service the SWR fetches.
+
+describe("Rewind (render harness)", () => {
+  it("mounts without crashing and shows rewind stats", async () => {
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<Rewind />);
+
+      // The Rewind hero always shows "PEEPBOT REWIND" header text
+      await screen.findByText(/PEEPBOT REWIND/i, undefined, { timeout: 3000 });
+    } finally {
+      restore();
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/setup/dom.ts
+++ b/frontend/src/__tests__/setup/dom.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/frontend/src/__tests__/setup/msw.ts
+++ b/frontend/src/__tests__/setup/msw.ts
@@ -1,0 +1,11 @@
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { server } from "@/mocks/server";
+
+// Lifecycle for the MSW node server. Render tests rely on this; pure-node tests
+// that don't make network requests are unaffected (handlers list is consulted
+// only when the test's code paths actually fetch).
+// "bypass" lets unhandled requests fall through to whatever global.fetch is —
+// this keeps existing node-environment tests that stub fetch manually working.
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/frontend/src/__tests__/setup/render.tsx
+++ b/frontend/src/__tests__/setup/render.tsx
@@ -1,0 +1,36 @@
+import { render, type RenderOptions } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { SWRConfig } from "swr";
+import { vi } from "vitest";
+
+/**
+ * Render a UI tree with the same provider stack the app uses, but with a
+ * disposable SWR cache so tests don't leak data between cases.
+ */
+export function renderWithProviders(ui: ReactElement, options?: RenderOptions) {
+  return render(
+    <SWRConfig
+      value={{
+        provider: () => new Map(),
+        dedupingInterval: 0,
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+      }}
+    >
+      {ui}
+    </SWRConfig>,
+    options,
+  );
+}
+
+/**
+ * Capture console.error calls during a test so the test can assert no React
+ * warnings or unhandled errors fired. Returns a restore function.
+ */
+export function trapConsoleError(): { errors: unknown[][]; restore: () => void } {
+  const errors: unknown[][] = [];
+  const spy = vi.spyOn(console, "error").mockImplementation((...args) => {
+    errors.push(args);
+  });
+  return { errors, restore: () => spy.mockRestore() };
+}

--- a/frontend/src/mocks/server.ts
+++ b/frontend/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,16 +2,47 @@ import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
+const alias = { "@": path.resolve(__dirname, "./src") };
+const plugins = [react()];
+
 export default defineConfig({
-  plugins: [react()],
+  plugins,
   test: {
-    environment: "node",
     passWithNoTests: true,
-    exclude: ["node_modules", "dist", ".next", "e2e/**"],
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
+    projects: [
+      // ── node-environment tests (api, places, middleware, components) ──────
+      {
+        plugins,
+        test: {
+          name: "node",
+          environment: "node",
+          include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+          exclude: [
+            "node_modules",
+            "dist",
+            ".next",
+            "e2e/**",
+            // Render tests run under jsdom in the project below
+            "src/__tests__/render/**",
+          ],
+          setupFiles: ["./src/__tests__/setup/dom.ts"],
+        },
+        resolve: { alias },
+      },
+      // ── jsdom render-harness tests ────────────────────────────────────────
+      {
+        plugins,
+        test: {
+          name: "render",
+          environment: "jsdom",
+          include: ["src/__tests__/render/**/*.test.tsx"],
+          setupFiles: [
+            "./src/__tests__/setup/msw.ts",
+            "./src/__tests__/setup/dom.ts",
+          ],
+        },
+        resolve: { alias },
+      },
+    ],
   },
 });


### PR DESCRIPTION
Adds MSW node server + vitest setup helpers (Tasks 39-40) and six jsdom render tests that mount EventsFeed, EventDetail, GuildSettingsForm, GalleryFeed, Rewind, and LoginHero through real SWR + MSW fixture data, asserting no mount crash, no console.error, and at least one fixture element in the DOM.

Uses a vitest projects split so the existing node-environment tests that stub globalThis.fetch directly are not affected by the MSW interceptors. Stubs IntersectionObserver for SocialGraph.tsx in the Rewind test.