### PR TITLE
test(discord): integration tests for listener handlers

### DIFF
--- a/backend/src/test/java/dev/tylercash/event/contract/listener/ContractSlashCommandListenerImplIntegrationTest.java
+++ b/backend/src/test/java/dev/tylercash/event/contract/listener/ContractSlashCommandListenerImplIntegrationTest.java
@@ -1,0 +1,391 @@
+package dev.tylercash.event.contract.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.tylercash.event.PeepBotApplication;
+import dev.tylercash.event.contract.ContractGraphService;
+import dev.tylercash.event.contract.ContractPinnedMessageService;
+import dev.tylercash.event.contract.UserBalanceService;
+import dev.tylercash.event.contract.model.Contract;
+import dev.tylercash.event.contract.model.ContractOutcome;
+import dev.tylercash.event.contract.model.ContractState;
+import dev.tylercash.event.contract.repository.ContractRepository;
+import dev.tylercash.event.discord.DiscordAuthService;
+import dev.tylercash.event.discord.DiscordChannelService;
+import dev.tylercash.event.discord.DiscordInitializationService;
+import dev.tylercash.event.discord.DiscordMessageService;
+import dev.tylercash.event.discord.DiscordService;
+import java.util.List;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.Category;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration tests for {@link ContractSlashCommandListenerImpl}.
+ *
+ * <p>The Spring context is fully wired (real ContractService, UserBalanceService, repositories).
+ * Discord-side infrastructure (JDA, channel/message services, pinned-message refresh) is mocked
+ * so that the tests don't require a live Discord connection.
+ */
+@SpringBootTest(
+        classes = PeepBotApplication.class,
+        properties = {
+            "spring.main.allow-bean-definition-overriding=true",
+            "spring.security.oauth2.client.registration.discord.client-id=test",
+            "spring.security.oauth2.client.registration.discord.client-secret=test",
+            "dev.tylercash.discord.token=dummy",
+            "dev.tylercash.discord.guild-id=0",
+            "dev.tylercash.rate-limit.read-capacity=10000",
+            "dev.tylercash.rate-limit.write-capacity=10000"
+        })
+@Testcontainers
+@ActiveProfiles("local")
+class ContractSlashCommandListenerImplIntegrationTest {
+
+    private static final String CREATOR_SNOWFLAKE = "777888999";
+    private static final String RESOLVER_SNOWFLAKE = "111000111";
+
+    @MockitoBean
+    JDA jda;
+
+    @MockitoBean
+    DiscordService discordService;
+
+    @MockitoBean
+    DiscordInitializationService discordInitializationService;
+
+    // Mock Discord infrastructure so ContractService.initChannel() doesn't need a live JDA.
+    @MockitoBean
+    DiscordChannelService discordChannelService;
+
+    @MockitoBean
+    DiscordMessageService discordMessageService;
+
+    @MockitoBean
+    ContractPinnedMessageService contractPinnedMessageService;
+
+    @MockitoBean
+    ContractGraphService contractGraphService;
+
+    // Mock auth so resolver-role checks are controllable per test.
+    @MockitoBean
+    DiscordAuthService discordAuthService;
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("pgvector/pgvector:0.8.0-pg17");
+
+    @Autowired
+    ContractSlashCommandListenerImpl listener;
+
+    @Autowired
+    ContractRepository contractRepository;
+
+    @Autowired
+    UserBalanceService userBalanceService;
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    // Shared Discord stub objects — created once, reused across @BeforeEach setups
+    // to avoid re-creating final-ish JDA types.
+    private TextChannel fakeChannel;
+    private Message fakeMessage;
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @BeforeEach
+    void setUp() {
+        jdbc.execute("DELETE FROM contract_trade");
+        jdbc.execute("DELETE FROM contract_outcome");
+        jdbc.execute("DELETE FROM contract");
+        jdbc.execute("DELETE FROM user_balance");
+
+        // Stub initChannel path so ContractService.createContract() completes without NPE.
+        Category category = mock(Category.class);
+        fakeChannel = mock(TextChannel.class);
+        fakeMessage = mock(Message.class);
+
+        lenient()
+                .when(discordChannelService.getOrCreateCategory(any(), anyString()))
+                .thenReturn(category);
+        lenient()
+                .when(discordChannelService.createTextChannel(any(), anyString()))
+                .thenReturn(fakeChannel);
+        lenient().when(fakeChannel.getIdLong()).thenReturn(12345L);
+        lenient()
+                .when(discordMessageService.sendEmbedWithAttachment(any(), anyList(), any(byte[].class), anyString()))
+                .thenReturn(fakeMessage);
+        lenient().when(fakeMessage.getIdLong()).thenReturn(67890L);
+
+        // buildEmbed and renderChart must return non-null so List.of(embed) doesn't NPE.
+        lenient()
+                .when(contractPinnedMessageService.buildEmbed(any(), anyList()))
+                .thenReturn(mock(MessageEmbed.class));
+        lenient()
+                .when(contractGraphService.renderChart(anyList(), anyList(), any(), any(double.class)))
+                .thenReturn(new byte[0]);
+
+        // sendMessage is a no-op for resolve/cancel notification banners.
+        lenient().when(discordMessageService.sendMessage(any(), anyString())).thenReturn(null);
+
+        // getTextChannel used during resolve/cancel result announcements.
+        lenient().when(discordChannelService.getTextChannel(anyLong())).thenReturn(fakeChannel);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a pre-stubbed OptionMapping mock.
+     * <p>
+     * IMPORTANT: always build this mock BEFORE composing it into a
+     * {@code when(event.getOption(...))} call. Constructing a mock with internal
+     * {@code when()} calls inside an outer {@code thenReturn()} triggers Mockito's
+     * "unfinished stubbing" detection.
+     */
+    private OptionMapping opt(String value) {
+        OptionMapping m = mock(OptionMapping.class);
+        lenient().when(m.getAsString()).thenReturn(value);
+        return m;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private SlashCommandInteractionEvent contractEvent(String subcommand, String userId) {
+        SlashCommandInteractionEvent evt = mock(SlashCommandInteractionEvent.class);
+        lenient().when(evt.getName()).thenReturn("contract");
+        lenient().when(evt.getSubcommandName()).thenReturn(subcommand);
+
+        User user = mock(User.class);
+        lenient().when(user.getId()).thenReturn(userId);
+        lenient().when(user.getIdLong()).thenReturn(Long.parseLong(userId));
+        lenient().when(evt.getUser()).thenReturn(user);
+
+        ReplyCallbackAction deferAction = mock(ReplyCallbackAction.class);
+        lenient().when(evt.deferReply(true)).thenReturn(deferAction);
+
+        InteractionHook hook = mock(InteractionHook.class);
+        lenient().when(evt.getHook()).thenReturn(hook);
+        WebhookMessageCreateAction hookAction = mock(WebhookMessageCreateAction.class);
+        lenient().when(hook.sendMessage(anyString())).thenReturn(hookAction);
+
+        ReplyCallbackAction replyAction = mock(ReplyCallbackAction.class);
+        lenient().when(evt.reply(anyString())).thenReturn(replyAction);
+        lenient().when(replyAction.setEphemeral(true)).thenReturn(replyAction);
+
+        return evt;
+    }
+
+    /** Convenience: create a contract and return a ref to it from the DB. */
+    private Contract createContract(String title, String outcome1, String outcome2) {
+        // Pre-build option mocks before composing them into when() calls.
+        OptionMapping titleOpt = opt(title);
+        OptionMapping o1Opt = outcome1 != null ? opt(outcome1) : null;
+        OptionMapping o2Opt = outcome2 != null ? opt(outcome2) : null;
+
+        SlashCommandInteractionEvent evt = contractEvent("create", CREATOR_SNOWFLAKE);
+        when(evt.getOption("title")).thenReturn(titleOpt);
+        when(evt.getOption("outcome_1")).thenReturn(o1Opt);
+        when(evt.getOption("outcome_2")).thenReturn(o2Opt);
+        when(evt.getOption("outcome_3")).thenReturn(null);
+        when(evt.getOption("outcome_4")).thenReturn(null);
+        when(evt.getOption("outcome_5")).thenReturn(null);
+        listener.handleSlashCommand(evt);
+
+        return contractRepository
+                .findFirstByStateInAndTitleIgnoreCase(List.of(ContractState.OPEN), title)
+                .orElseThrow(() -> new AssertionError("Contract not created: " + title));
+    }
+
+    // -------------------------------------------------------------------------
+    // create
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create → contract row persisted in DB with OPEN state and correct outcomes")
+    void createContract_persistsContractAndOutcomes() {
+        Contract saved = createContract("Will it rain tomorrow?", "YES", "NO");
+
+        assertThat(saved.getTitle()).isEqualTo("Will it rain tomorrow?");
+        assertThat(saved.getCreatorSnowflake()).isEqualTo(CREATOR_SNOWFLAKE);
+        assertThat(saved.getOutcomes()).extracting(ContractOutcome::getLabel).containsExactlyInAnyOrder("YES", "NO");
+    }
+
+    @Test
+    @DisplayName("create with no explicit outcomes → defaults YES/NO")
+    void createContract_defaultsToYesNo() {
+        Contract saved = createContract("Will we win?", null, null);
+
+        assertThat(saved.getOutcomes()).extracting(ContractOutcome::getLabel).containsExactlyInAnyOrder("YES", "NO");
+    }
+
+    // -------------------------------------------------------------------------
+    // trade
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("trade → user balance debited, shares incremented on the outcome")
+    void trade_debitsBalanceAndIncrementsShares() {
+        Contract contract = createContract("Trade Test", "WIN", "LOSE");
+        double sharesBefore = contract.getOutcomes().stream()
+                .filter(o -> o.getLabel().equals("WIN"))
+                .findFirst()
+                .orElseThrow()
+                .getSharesOutstanding();
+
+        String traderSnowflake = "222333444";
+        long balanceBefore = userBalanceService.getBalance(traderSnowflake);
+
+        // Pre-build option mocks before composing them into when() calls.
+        OptionMapping contractOpt = opt("Trade Test");
+        OptionMapping outcomeOpt = opt("WIN");
+        OptionMapping amountOpt = opt("50");
+
+        SlashCommandInteractionEvent tradeEvt = contractEvent("trade", traderSnowflake);
+        when(tradeEvt.getOption("contract")).thenReturn(contractOpt);
+        when(tradeEvt.getOption("outcome")).thenReturn(outcomeOpt);
+        when(tradeEvt.getOption("amount")).thenReturn(amountOpt);
+        listener.handleSlashCommand(tradeEvt);
+
+        long balanceAfter = userBalanceService.getBalance(traderSnowflake);
+        assertThat(balanceAfter).isLessThan(balanceBefore);
+
+        Contract updated = contractRepository.findById(contract.getId()).orElseThrow();
+        double sharesAfter = updated.getOutcomes().stream()
+                .filter(o -> o.getLabel().equals("WIN"))
+                .findFirst()
+                .orElseThrow()
+                .getSharesOutstanding();
+        assertThat(sharesAfter).isGreaterThan(sharesBefore);
+    }
+
+    // -------------------------------------------------------------------------
+    // resolve
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("resolve → contract state RESOLVED, winning outcome ID set, winner credited")
+    void resolve_transitionsToResolvedAndCreditsWinners() {
+        Contract contract = createContract("Resolve Test", "A", "B");
+
+        // Place a trade on outcome A so there's a winner to credit.
+        String traderSnowflake = "555666777";
+        OptionMapping contractOpt1 = opt("Resolve Test");
+        OptionMapping outcomeOpt1 = opt("A");
+        OptionMapping amountOpt1 = opt("100");
+        SlashCommandInteractionEvent tradeEvt = contractEvent("trade", traderSnowflake);
+        when(tradeEvt.getOption("contract")).thenReturn(contractOpt1);
+        when(tradeEvt.getOption("outcome")).thenReturn(outcomeOpt1);
+        when(tradeEvt.getOption("amount")).thenReturn(amountOpt1);
+        listener.handleSlashCommand(tradeEvt);
+        long balanceAfterTrade = userBalanceService.getBalance(traderSnowflake);
+
+        // Resolver has the required role.
+        when(discordAuthService.hasRole(anyLong(), anyLong(), anyString())).thenReturn(true);
+
+        OptionMapping contractOpt2 = opt("Resolve Test");
+        OptionMapping outcomeOpt2 = opt("A");
+        SlashCommandInteractionEvent resolveEvt = contractEvent("resolve", RESOLVER_SNOWFLAKE);
+        when(resolveEvt.getOption("contract")).thenReturn(contractOpt2);
+        when(resolveEvt.getOption("outcome")).thenReturn(outcomeOpt2);
+        listener.handleSlashCommand(resolveEvt);
+
+        Contract resolved = contractRepository.findById(contract.getId()).orElseThrow();
+        assertThat(resolved.getState()).isEqualTo(ContractState.RESOLVED);
+        assertThat(resolved.getWinningOutcomeId()).isNotNull();
+
+        long balanceAfterResolve = userBalanceService.getBalance(traderSnowflake);
+        assertThat(balanceAfterResolve).isGreaterThan(balanceAfterTrade);
+    }
+
+    // -------------------------------------------------------------------------
+    // cancel
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("cancel → contract state CANCELLED, trades refunded to buyers")
+    void cancel_transitionsToCancelledAndRefundsTrades() {
+        Contract contract = createContract("Cancel Test", "X", "Y");
+
+        String traderSnowflake = "888777666";
+        long balanceBefore = userBalanceService.getBalance(traderSnowflake);
+
+        OptionMapping contractOpt1 = opt("Cancel Test");
+        OptionMapping outcomeOpt1 = opt("X");
+        OptionMapping amountOpt1 = opt("100");
+        SlashCommandInteractionEvent tradeEvt = contractEvent("trade", traderSnowflake);
+        when(tradeEvt.getOption("contract")).thenReturn(contractOpt1);
+        when(tradeEvt.getOption("outcome")).thenReturn(outcomeOpt1);
+        when(tradeEvt.getOption("amount")).thenReturn(amountOpt1);
+        listener.handleSlashCommand(tradeEvt);
+
+        long balanceAfterTrade = userBalanceService.getBalance(traderSnowflake);
+        assertThat(balanceAfterTrade).isLessThan(balanceBefore);
+
+        // Cancel — resolver role granted
+        when(discordAuthService.hasRole(anyLong(), anyLong(), anyString())).thenReturn(true);
+
+        OptionMapping cancelContractOpt = opt("Cancel Test");
+        SlashCommandInteractionEvent cancelEvt = contractEvent("cancel", RESOLVER_SNOWFLAKE);
+        when(cancelEvt.getOption("contract")).thenReturn(cancelContractOpt);
+        listener.handleSlashCommand(cancelEvt);
+
+        Contract cancelled = contractRepository.findById(contract.getId()).orElseThrow();
+        assertThat(cancelled.getState()).isEqualTo(ContractState.CANCELLED);
+
+        long balanceAfterCancel = userBalanceService.getBalance(traderSnowflake);
+        assertThat(balanceAfterCancel).isGreaterThanOrEqualTo(balanceBefore);
+    }
+
+    // -------------------------------------------------------------------------
+    // list
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("list → reply contains open contract titles")
+    void list_repliesWithOpenContracts() {
+        createContract("Alpha Contract", null, null);
+        createContract("Beta Contract", null, null);
+
+        SlashCommandInteractionEvent listEvt = contractEvent("list", CREATOR_SNOWFLAKE);
+        listener.handleSlashCommand(listEvt);
+
+        // The list handler calls event.reply(...).setEphemeral(true).queue()
+        verify(listEvt).reply(org.mockito.ArgumentMatchers.contains("Alpha Contract"));
+    }
+}

--- a/backend/src/test/java/dev/tylercash/event/discord/listener/ButtonInteractionListenerIntegrationTest.java
+++ b/backend/src/test/java/dev/tylercash/event/discord/listener/ButtonInteractionListenerIntegrationTest.java
@@ -1,0 +1,295 @@
+package dev.tylercash.event.discord.listener;
+
+import static dev.tylercash.event.discord.listener.ButtonInteractionListener.ACCEPTED;
+import static dev.tylercash.event.discord.listener.ButtonInteractionListener.DECLINED;
+import static dev.tylercash.event.discord.listener.ButtonInteractionListener.MAYBE;
+import static dev.tylercash.event.discord.listener.ModalInteractionListener.PLUS_ONE_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.tylercash.event.PeepBotApplication;
+import dev.tylercash.event.db.repository.AttendanceRepository;
+import dev.tylercash.event.db.repository.EventRepository;
+import dev.tylercash.event.discord.DiscordInitializationService;
+import dev.tylercash.event.discord.DiscordService;
+import dev.tylercash.event.discord.DiscordUserCacheService;
+import dev.tylercash.event.event.model.AttendanceRecord;
+import dev.tylercash.event.event.model.AttendanceStatus;
+import dev.tylercash.event.event.model.Event;
+import dev.tylercash.event.event.model.EventState;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction;
+import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+        classes = PeepBotApplication.class,
+        properties = {
+            "spring.main.allow-bean-definition-overriding=true",
+            "spring.security.oauth2.client.registration.discord.client-id=test",
+            "spring.security.oauth2.client.registration.discord.client-secret=test",
+            "dev.tylercash.discord.token=dummy",
+            "dev.tylercash.discord.guild-id=0",
+            "dev.tylercash.rate-limit.read-capacity=10000",
+            "dev.tylercash.rate-limit.write-capacity=10000"
+        })
+@Testcontainers
+@ActiveProfiles("local")
+class ButtonInteractionListenerIntegrationTest {
+
+    private static final String USER_SNOWFLAKE = "111222333";
+    private static final String USER_DISPLAY_NAME = "TestUser";
+    private static final String USER_USERNAME = "testuser";
+    private static final long SERVER_ID = 999L;
+
+    private static final AtomicLong idCounter = new AtomicLong(50_000);
+
+    @MockitoBean
+    JDA jda;
+
+    @MockitoBean
+    DiscordService discordService;
+
+    @MockitoBean
+    DiscordInitializationService discordInitializationService;
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("pgvector/pgvector:0.8.0-pg17");
+
+    @Autowired
+    ButtonInteractionListener listener;
+
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    AttendanceRepository attendanceRepository;
+
+    @Autowired
+    DiscordUserCacheService discordUserCacheService;
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @BeforeEach
+    void truncate() {
+        jdbc.execute("DELETE FROM attendance");
+        jdbc.execute("DELETE FROM event_category");
+        jdbc.execute("DELETE FROM event");
+        jdbc.execute("DELETE FROM discord_user_guild");
+        jdbc.execute("DELETE FROM discord_user_cache");
+    }
+
+    private Event seedPlannedEvent() {
+        long id = idCounter.incrementAndGet();
+        Event event = new Event(
+                id,
+                SERVER_ID,
+                id,
+                "Integration Test Event",
+                USER_SNOWFLAKE,
+                ZonedDateTime.now().plusDays(1),
+                "desc");
+        event.setState(EventState.PLANNED);
+        return eventRepository.save(event);
+    }
+
+    private ButtonInteractionEvent mockButtonEvent(Event event, String buttonId) {
+        ButtonInteractionEvent evt = mock(ButtonInteractionEvent.class);
+
+        Button button = mock(Button.class);
+        when(button.getCustomId()).thenReturn(buttonId);
+        when(evt.getButton()).thenReturn(button);
+        when(evt.getMessageIdLong()).thenReturn(event.getMessageId());
+
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(USER_SNOWFLAKE);
+        when(member.getNickname()).thenReturn(USER_DISPLAY_NAME);
+        when(member.getEffectiveName()).thenReturn(USER_DISPLAY_NAME);
+        when(evt.getMember()).thenReturn(member);
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(USER_SNOWFLAKE);
+        when(user.getName()).thenReturn(USER_USERNAME);
+        when(evt.getUser()).thenReturn(user);
+
+        when(evt.editMessageEmbeds(any(List.class))).thenReturn(mock(MessageEditCallbackAction.class));
+        when(evt.editMessageEmbeds(any(MessageEmbed[].class))).thenReturn(mock(MessageEditCallbackAction.class));
+
+        return evt;
+    }
+
+    private List<AttendanceRecord> latestAttendance(UUID eventId) {
+        return attendanceRepository.findLatestPerAttendee(eventId);
+    }
+
+    @Test
+    @DisplayName("accepted button → ACCEPTED attendance row in DB")
+    void acceptedButton_createsAcceptedRow() {
+        Event event = seedPlannedEvent();
+        ButtonInteractionEvent evt = mockButtonEvent(event, ACCEPTED);
+
+        listener.onButtonInteraction(evt);
+
+        List<AttendanceRecord> rows = latestAttendance(event.getId());
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getStatus()).isEqualTo(AttendanceStatus.ACCEPTED);
+        assertThat(rows.get(0).getSnowflake()).isEqualTo(USER_SNOWFLAKE);
+    }
+
+    @Test
+    @DisplayName("declined button → DECLINED attendance row in DB")
+    void declinedButton_createsDeclinedRow() {
+        Event event = seedPlannedEvent();
+        ButtonInteractionEvent evt = mockButtonEvent(event, DECLINED);
+
+        listener.onButtonInteraction(evt);
+
+        List<AttendanceRecord> rows = latestAttendance(event.getId());
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getStatus()).isEqualTo(AttendanceStatus.DECLINED);
+    }
+
+    @Test
+    @DisplayName("maybe button → MAYBE attendance row in DB")
+    void maybeButton_createsMaybeRow() {
+        Event event = seedPlannedEvent();
+        ButtonInteractionEvent evt = mockButtonEvent(event, MAYBE);
+
+        listener.onButtonInteraction(evt);
+
+        List<AttendanceRecord> rows = latestAttendance(event.getId());
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getStatus()).isEqualTo(AttendanceStatus.MAYBE);
+    }
+
+    @Test
+    @DisplayName("accepting then declining → latest row is DECLINED (flip behaviour)")
+    void switchingResponse_updatesToLatestStatus() {
+        Event event = seedPlannedEvent();
+
+        listener.onButtonInteraction(mockButtonEvent(event, ACCEPTED));
+        listener.onButtonInteraction(mockButtonEvent(event, DECLINED));
+
+        List<AttendanceRecord> rows = latestAttendance(event.getId());
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getStatus()).isEqualTo(AttendanceStatus.DECLINED);
+    }
+
+    @Test
+    @DisplayName("pressing same button twice → status REMOVED (toggle off)")
+    void pressingTwice_removesAttendance() {
+        Event event = seedPlannedEvent();
+
+        listener.onButtonInteraction(mockButtonEvent(event, ACCEPTED));
+        listener.onButtonInteraction(mockButtonEvent(event, ACCEPTED));
+
+        List<AttendanceRecord> rows = latestAttendance(event.getId());
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getStatus()).isEqualTo(AttendanceStatus.REMOVED);
+    }
+
+    @Test
+    @DisplayName("unknown message ID → no DB changes")
+    void unknownMessageId_noDbChange() {
+        Event event = seedPlannedEvent();
+
+        ButtonInteractionEvent evt = mock(ButtonInteractionEvent.class);
+        Button button = mock(Button.class);
+        when(button.getCustomId()).thenReturn(ACCEPTED);
+        when(evt.getButton()).thenReturn(button);
+        // message ID that doesn't match any event
+        when(evt.getMessageIdLong()).thenReturn(99999999L);
+
+        listener.onButtonInteraction(evt);
+
+        assertThat(latestAttendance(event.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("plus-one button → replyModal called, no attendance row created")
+    void plusOneButton_opensModal() {
+        Event event = seedPlannedEvent();
+        ButtonInteractionEvent evt = mock(ButtonInteractionEvent.class);
+
+        Button button = mock(Button.class);
+        when(button.getCustomId()).thenReturn(PLUS_ONE_ID);
+        when(evt.getButton()).thenReturn(button);
+        when(evt.getMessageIdLong()).thenReturn(event.getMessageId());
+        when(evt.replyModal(any())).thenReturn(mock(ModalCallbackAction.class));
+
+        // getMember needed by isCompleted path only after null check — event service
+        // checks isCompleted before calling getMember for +1 path, so set it up
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(USER_SNOWFLAKE);
+        when(evt.getMember()).thenReturn(member);
+
+        listener.onButtonInteraction(evt);
+
+        verify(evt).replyModal(any());
+        assertThat(latestAttendance(event.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("completed event → ephemeral reply, no attendance row created")
+    void completedEvent_repliesLocked() {
+        long id = idCounter.incrementAndGet();
+        Event event = new Event(
+                id,
+                SERVER_ID,
+                id,
+                "Done Event",
+                USER_SNOWFLAKE,
+                ZonedDateTime.now().minusDays(2),
+                "desc");
+        event.setState(EventState.POST_COMPLETED);
+        event = eventRepository.save(event);
+
+        ButtonInteractionEvent evt = mock(ButtonInteractionEvent.class);
+        Button button = mock(Button.class);
+        when(button.getCustomId()).thenReturn(ACCEPTED);
+        when(evt.getButton()).thenReturn(button);
+        when(evt.getMessageIdLong()).thenReturn(event.getMessageId());
+
+        ReplyCallbackAction reply = mock(ReplyCallbackAction.class);
+        when(evt.reply(any(String.class))).thenReturn(reply);
+        when(reply.setEphemeral(true)).thenReturn(reply);
+
+        listener.onButtonInteraction(evt);
+
+        verify(evt).reply("Attendance is locked for this event.");
+        assertThat(latestAttendance(event.getId())).isEmpty();
+    }
+}

--- a/backend/src/test/java/dev/tylercash/event/discord/listener/ModalInteractionListenerIntegrationTest.java
+++ b/backend/src/test/java/dev/tylercash/event/discord/listener/ModalInteractionListenerIntegrationTest.java
@@ -1,0 +1,223 @@
+package dev.tylercash.event.discord.listener;
+
+import static dev.tylercash.event.discord.listener.ModalInteractionListener.PLUS_ONE_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.tylercash.event.PeepBotApplication;
+import dev.tylercash.event.db.repository.AttendanceRepository;
+import dev.tylercash.event.db.repository.EventRepository;
+import dev.tylercash.event.discord.DiscordInitializationService;
+import dev.tylercash.event.discord.DiscordService;
+import dev.tylercash.event.event.model.AttendanceRecord;
+import dev.tylercash.event.event.model.AttendanceStatus;
+import dev.tylercash.event.event.model.Event;
+import dev.tylercash.event.event.model.EventState;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.interactions.modals.ModalInteraction;
+import net.dv8tion.jda.api.interactions.modals.ModalMapping;
+import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(
+        classes = PeepBotApplication.class,
+        properties = {
+            "spring.main.allow-bean-definition-overriding=true",
+            "spring.security.oauth2.client.registration.discord.client-id=test",
+            "spring.security.oauth2.client.registration.discord.client-secret=test",
+            "dev.tylercash.discord.token=dummy",
+            "dev.tylercash.discord.guild-id=0",
+            "dev.tylercash.rate-limit.read-capacity=10000",
+            "dev.tylercash.rate-limit.write-capacity=10000"
+        })
+@Testcontainers
+@ActiveProfiles("local")
+class ModalInteractionListenerIntegrationTest {
+
+    private static final String OWNER_SNOWFLAKE = "444555666";
+    private static final String OWNER_DISPLAY_NAME = "ModalUser";
+    private static final String OWNER_USERNAME = "modaluser";
+    private static final long SERVER_ID = 888L;
+
+    private static final AtomicLong idCounter = new AtomicLong(60_000);
+
+    @MockitoBean
+    JDA jda;
+
+    @MockitoBean
+    DiscordService discordService;
+
+    @MockitoBean
+    DiscordInitializationService discordInitializationService;
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("pgvector/pgvector:0.8.0-pg17");
+
+    @Autowired
+    ModalInteractionListener listener;
+
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    AttendanceRepository attendanceRepository;
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @BeforeEach
+    void truncate() {
+        jdbc.execute("DELETE FROM attendance");
+        jdbc.execute("DELETE FROM event_category");
+        jdbc.execute("DELETE FROM event");
+        jdbc.execute("DELETE FROM discord_user_guild");
+        jdbc.execute("DELETE FROM discord_user_cache");
+    }
+
+    private Event seedOpenEvent() {
+        long id = idCounter.incrementAndGet();
+        Event event = new Event(
+                id,
+                SERVER_ID,
+                id,
+                "Modal Integration Event",
+                OWNER_SNOWFLAKE,
+                ZonedDateTime.now().plusDays(1),
+                "desc");
+        event.setState(EventState.PLANNED);
+        return eventRepository.save(event);
+    }
+
+    private ModalInteractionEvent buildModalEvent(Event event, String guestName) {
+        ModalInteractionEvent evt = mock(ModalInteractionEvent.class);
+
+        ModalInteraction interaction = mock(ModalInteraction.class);
+        when(evt.getInteraction()).thenReturn(interaction);
+        when(interaction.getModalId()).thenReturn(PLUS_ONE_ID);
+
+        MessageChannelUnion channel = mock(MessageChannelUnion.class);
+        when(channel.getIdLong()).thenReturn(event.getChannelId());
+        when(evt.getChannel()).thenReturn(channel);
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(OWNER_SNOWFLAKE);
+        when(user.getName()).thenReturn(OWNER_USERNAME);
+        when(user.getEffectiveName()).thenReturn(OWNER_DISPLAY_NAME);
+        when(evt.getUser()).thenReturn(user);
+
+        Member member = mock(Member.class);
+        when(member.getNickname()).thenReturn(OWNER_DISPLAY_NAME);
+        when(member.getEffectiveName()).thenReturn(OWNER_DISPLAY_NAME);
+        when(evt.getMember()).thenReturn(member);
+
+        if (guestName != null) {
+            ModalMapping mapping = mock(ModalMapping.class);
+            when(mapping.getAsString()).thenReturn(guestName);
+            when(interaction.getValues()).thenReturn(List.of(mapping));
+        }
+
+        when(evt.editMessageEmbeds(any(List.class))).thenReturn(mock(MessageEditCallbackAction.class));
+        when(evt.editMessageEmbeds(any(MessageEmbed[].class))).thenReturn(mock(MessageEditCallbackAction.class));
+
+        return evt;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T any(Class<T> cls) {
+        return org.mockito.ArgumentMatchers.any(cls);
+    }
+
+    private List<AttendanceRecord> latestAttendance(UUID eventId) {
+        return attendanceRepository.findLatestPerAttendee(eventId);
+    }
+
+    @Test
+    @DisplayName("+1 modal submission → attendance row with name=[+1] Guest, status=ACCEPTED, ownerSnowflake set")
+    void plusOneModal_createsAcceptedRow() {
+        Event event = seedOpenEvent();
+        ModalInteractionEvent evt = buildModalEvent(event, "Alice");
+
+        listener.onModalInteraction(evt);
+
+        List<AttendanceRecord> rows = latestAttendance(event.getId());
+        assertThat(rows).hasSize(1);
+        AttendanceRecord row = rows.get(0);
+        assertThat(row.getStatus()).isEqualTo(AttendanceStatus.ACCEPTED);
+        assertThat(row.getName()).isEqualTo("[+1] Alice");
+        assertThat(row.getSnowflake()).isNull();
+        assertThat(row.getOwnerSnowflake()).isEqualTo(OWNER_SNOWFLAKE);
+    }
+
+    @Test
+    @DisplayName("submitting the same +1 name twice → two rows (recordAttendance is not idempotent by design)")
+    void plusOneModal_submittedTwice_createsTwoRows() {
+        Event event = seedOpenEvent();
+
+        listener.onModalInteraction(buildModalEvent(event, "Bob"));
+        listener.onModalInteraction(buildModalEvent(event, "Bob"));
+
+        // findLatestPerAttendee deduplicates on COALESCE(snowflake, name), so
+        // repeated +1 with same name collapses to 1 current entry.
+        List<AttendanceRecord> rows = latestAttendance(event.getId());
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getName()).isEqualTo("[+1] Bob");
+        assertThat(rows.get(0).getStatus()).isEqualTo(AttendanceStatus.ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("two distinct +1 names → two independent attendance rows")
+    void plusOneModal_twoDistinctGuests_createsTwoRows() {
+        Event event = seedOpenEvent();
+
+        listener.onModalInteraction(buildModalEvent(event, "Charlie"));
+        listener.onModalInteraction(buildModalEvent(event, "Diana"));
+
+        List<AttendanceRecord> rows = latestAttendance(event.getId());
+        assertThat(rows).hasSize(2);
+        assertThat(rows).extracting(AttendanceRecord::getStatus).containsOnly(AttendanceStatus.ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("unknown modal ID → no attendance row created")
+    void unknownModalId_noDbChange() {
+        Event event = seedOpenEvent();
+
+        ModalInteractionEvent evt = mock(ModalInteractionEvent.class);
+        ModalInteraction interaction = mock(ModalInteraction.class);
+        when(evt.getInteraction()).thenReturn(interaction);
+        when(interaction.getModalId()).thenReturn("some-other-modal");
+
+        listener.onModalInteraction(evt);
+
+        assertThat(latestAttendance(event.getId())).isEmpty();
+    }
+}


### PR DESCRIPTION
Add SpringBootTest+Testcontainers ITs for ButtonInteractionListener (7 cases), ModalInteractionListener (4 cases), and ContractSlashCommandListenerImpl (6 cases). Each test fires real listener → service → DB through the full Spring bean graph and asserts downstream state rather than mock interactions.