### PR TITLE
test(frontend): render harness — error and empty-state coverage

### DIFF
--- a/frontend/src/__tests__/render/errors/EventDetail.notFound.test.tsx
+++ b/frontend/src/__tests__/render/errors/EventDetail.notFound.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { screen } from "@testing-library/react";
+import { server } from "@/mocks/server";
+import { renderWithProviders, trapConsoleError } from "../../setup/render";
+import { EventDetail } from "@/components/event/EventDetail";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "999" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/events/999",
+}));
+
+describe("EventDetail render — 404 not found", () => {
+  it("renders a loading/not-found state without crashing when /event/:id returns 404", async () => {
+    server.use(
+      http.get(/\/event\/999$/, () => new HttpResponse(null, { status: 404 })),
+    );
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<EventDetail id="999" />);
+      // TODO: EventDetail.tsx has NO dedicated not-found/error UI state — bug to fix.
+      // When useEvent errors (404), `data` stays undefined and `isLoading` becomes false
+      // but the component stays in the `if (isLoading || !data)` branch showing "loading…"
+      // forever rather than surfacing a not-found message.
+      // Bug location: frontend/src/components/event/EventDetail.tsx line 47-49
+      // Fix needed: check `error` from useEvent() and render a "event not found" message.
+      await screen.findByText(/loading/i, undefined, { timeout: 3000 });
+    } finally {
+      restore();
+    }
+    // Allow some console noise from the fetch error
+    expect(errors.length).toBeLessThan(5);
+  });
+});

--- a/frontend/src/__tests__/render/errors/EventsFeed.empty.test.tsx
+++ b/frontend/src/__tests__/render/errors/EventsFeed.empty.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { screen } from "@testing-library/react";
+import { server } from "@/mocks/server";
+import { renderWithProviders, trapConsoleError } from "../../setup/render";
+import { EventsFeed } from "@/components/feed/EventsFeed";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/",
+}));
+
+describe("EventsFeed render — empty state", () => {
+  it("renders 0 upcoming without crashing when /event returns an empty page", async () => {
+    server.use(
+      http.get(/\/event$/, () =>
+        HttpResponse.json({ content: [], totalElements: 0 }),
+      ),
+    );
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<EventsFeed />);
+      // EventsFeed shows the count badge — "0 upcoming" when no events
+      await screen.findByText(/upcoming/i, undefined, { timeout: 3000 });
+      // The count badge should show "0"
+      const badge = screen.getByText("0");
+      expect(badge).toBeTruthy();
+    } finally {
+      restore();
+    }
+    expect(errors).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/render/errors/EventsFeed.errors.test.tsx
+++ b/frontend/src/__tests__/render/errors/EventsFeed.errors.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { screen } from "@testing-library/react";
+import { server } from "@/mocks/server";
+import { renderWithProviders, trapConsoleError } from "../../setup/render";
+import { EventsFeed } from "@/components/feed/EventsFeed";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/",
+}));
+
+describe("EventsFeed render — server error", () => {
+  it("renders an error state instead of crashing when /event returns 500", async () => {
+    server.use(
+      http.get(/\/event$/, () => new HttpResponse(null, { status: 500 })),
+    );
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<EventsFeed />);
+      // EventsFeed.tsx line 56-59: error && !events.length renders "can't reach the backend."
+      await screen.findByText(/can't reach the backend/i, undefined, {
+        timeout: 3000,
+      });
+    } finally {
+      restore();
+    }
+    // SWR will log the fetch error — allow some console noise, just not React warnings
+    expect(errors.length).toBeLessThan(5);
+  });
+});

--- a/frontend/src/__tests__/render/errors/GalleryFeed.outage.test.tsx
+++ b/frontend/src/__tests__/render/errors/GalleryFeed.outage.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { screen } from "@testing-library/react";
+import { server } from "@/mocks/server";
+import { renderWithProviders, trapConsoleError } from "../../setup/render";
+import { GalleryFeed } from "@/components/gallery/GalleryFeed";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/gallery",
+}));
+
+describe("GalleryFeed render — Immich outage (502)", () => {
+  it("renders an outage message instead of crashing when /gallery returns 502", async () => {
+    server.use(
+      http.get(/\/gallery$/, () => new HttpResponse(null, { status: 502 })),
+    );
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<GalleryFeed />);
+      // GalleryFeed.tsx line 18-25: error branch renders "can't load gallery right now."
+      await screen.findByText(/can't load gallery right now/i, undefined, {
+        timeout: 3000,
+      });
+    } finally {
+      restore();
+    }
+    expect(errors.length).toBeLessThan(5);
+  });
+});

--- a/frontend/src/__tests__/render/errors/GuildSettingsForm.unauthorized.test.tsx
+++ b/frontend/src/__tests__/render/errors/GuildSettingsForm.unauthorized.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { screen } from "@testing-library/react";
+import { server } from "@/mocks/server";
+import { renderWithProviders, trapConsoleError } from "../../setup/render";
+import { GuildSettingsForm } from "@/components/guild/GuildSettingsForm";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "mockguild-1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/guild/mockguild-1/settings",
+}));
+
+describe("GuildSettingsForm render — 403 unauthorized", () => {
+  it("renders without crashing when /guild/:id/settings returns 403", async () => {
+    server.use(
+      http.get(/\/guild\/[^/]+\/settings$/, () =>
+        new HttpResponse(null, { status: 403 }),
+      ),
+    );
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<GuildSettingsForm guildId="mockguild-1" />);
+      // TODO: GuildSettingsForm.tsx has NO dedicated unauthorized/error UI state — bug to fix.
+      // When useGuildSettings() errors with 403 (UnauthorizedError via apiFetch/fetcher),
+      // `settings` stays undefined so the component shows "loading…" forever.
+      // There is a non-admin redirect (line 48-50) but it only fires when `user.admin` is false,
+      // not when the settings fetch itself is unauthorized.
+      // Bug location: frontend/src/components/guild/GuildSettingsForm.tsx line 71-73
+      // Fix needed: read `error` from useGuildSettings() and render an access-denied message
+      // (or redirect) when it throws UnauthorizedError.
+      await screen.findByText(/loading/i, undefined, { timeout: 3000 });
+    } finally {
+      restore();
+    }
+    // Allow console noise from the fetch error / UnauthorizedError
+    expect(errors.length).toBeLessThan(5);
+  });
+});

--- a/frontend/src/__tests__/render/errors/Rewind.empty.test.tsx
+++ b/frontend/src/__tests__/render/errors/Rewind.empty.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { screen } from "@testing-library/react";
+import { server } from "@/mocks/server";
+import { renderWithProviders, trapConsoleError } from "../../setup/render";
+import { Rewind } from "@/components/rewind/Rewind";
+
+// jsdom doesn't implement IntersectionObserver — stub it so SocialGraph.tsx
+// doesn't throw when it wires up its scroll-in-view animation.
+beforeAll(() => {
+  if (typeof globalThis.IntersectionObserver === "undefined") {
+    globalThis.IntersectionObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof IntersectionObserver;
+  }
+});
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/rewind",
+}));
+
+describe("Rewind render — empty years list", () => {
+  it("renders without crashing when /rewind/years returns []", async () => {
+    server.use(
+      http.get(/\/rewind\/years$/, () => HttpResponse.json([])),
+    );
+    const { errors, restore } = trapConsoleError();
+    try {
+      renderWithProviders(<Rewind />);
+      // Rewind.tsx line 23: availableYears = years ?? [currentYear]
+      // When years resolves to [], availableYears = [] so no year buttons are shown.
+      // The hero section still renders with the current year in the h1.
+      // There is no dedicated empty-state message — the component renders the current year
+      // from useState(currentYear) in the h1 and shows "loading rewind…" until rewind data loads.
+      await screen.findByText(/peepbot rewind/i, undefined, { timeout: 3000 });
+    } finally {
+      restore();
+    }
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds six error/empty-state render tests under src/__tests__/render/errors/:
- EventsFeed.errors.test.tsx  — GET /event → 500 renders "can't reach the backend" ✓
- EventsFeed.empty.test.tsx   — GET /event → empty page renders "0 upcoming" badge ✓
- EventDetail.notFound.test.tsx — GET /event/:id → 404; component has no not-found UI (BUG)
- GuildSettingsForm.unauthorized.test.tsx — GET settings → 403; component has no error UI (BUG)
- GalleryFeed.outage.test.tsx — GET /gallery → 502 renders "can't load gallery right now." ✓
- Rewind.empty.test.tsx       — GET /rewind/years → [] renders hero without crashing ✓

Bugs found (not fixed here — separate PRs):
- EventDetail.tsx:47-49: useEvent()'s `error` field is never read; a 404 leaves the component stuck on "loading…" indefinitely instead of showing "event not found".
- GuildSettingsForm.tsx:71-73: useGuildSettings()'s `error` field is never read; a 403 (UnauthorizedError) leaves the component stuck on "loading…" with no access-denied message.