### PR TITLE
fix(frontend): render error UI when useEvent / useGuildSettings fail

### DIFF
--- a/frontend/src/__tests__/render/errors/EventDetail.notFound.test.tsx
+++ b/frontend/src/__tests__/render/errors/EventDetail.notFound.test.tsx
@@ -14,20 +14,15 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("EventDetail render — 404 not found", () => {
-  it("renders a loading/not-found state without crashing when /event/:id returns 404", async () => {
+  it("renders an 'event not found' error panel when /event/:id returns 404", async () => {
     server.use(
       http.get(/\/event\/999$/, () => new HttpResponse(null, { status: 404 })),
     );
     const { errors, restore } = trapConsoleError();
     try {
       renderWithProviders(<EventDetail id="999" />);
-      // TODO: EventDetail.tsx has NO dedicated not-found/error UI state — bug to fix.
-      // When useEvent errors (404), `data` stays undefined and `isLoading` becomes false
-      // but the component stays in the `if (isLoading || !data)` branch showing "loading…"
-      // forever rather than surfacing a not-found message.
-      // Bug location: frontend/src/components/event/EventDetail.tsx line 47-49
-      // Fix needed: check `error` from useEvent() and render a "event not found" message.
-      await screen.findByText(/loading/i, undefined, { timeout: 3000 });
+      await screen.findByText(/event not found/i, undefined, { timeout: 3000 });
+      expect(screen.queryByText(/^loading…$/i)).toBeNull();
     } finally {
       restore();
     }

--- a/frontend/src/__tests__/render/errors/GuildSettingsForm.unauthorized.test.tsx
+++ b/frontend/src/__tests__/render/errors/GuildSettingsForm.unauthorized.test.tsx
@@ -14,7 +14,10 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("GuildSettingsForm render — 403 unauthorized", () => {
-  it("renders without crashing when /guild/:id/settings returns 403", async () => {
+  it("renders an 'access denied' error panel when /guild/:id/settings returns 403", async () => {
+    // Note: apiFetch redirects to /login in live mode on 401/403, but in mock mode
+    // (NEXT_PUBLIC_API_MODE=mock) it throws UnauthorizedError without the redirect.
+    // The component now reads error from useGuildSettings() and renders an error panel.
     server.use(
       http.get(/\/guild\/[^/]+\/settings$/, () =>
         new HttpResponse(null, { status: 403 }),
@@ -23,15 +26,8 @@ describe("GuildSettingsForm render — 403 unauthorized", () => {
     const { errors, restore } = trapConsoleError();
     try {
       renderWithProviders(<GuildSettingsForm guildId="mockguild-1" />);
-      // TODO: GuildSettingsForm.tsx has NO dedicated unauthorized/error UI state — bug to fix.
-      // When useGuildSettings() errors with 403 (UnauthorizedError via apiFetch/fetcher),
-      // `settings` stays undefined so the component shows "loading…" forever.
-      // There is a non-admin redirect (line 48-50) but it only fires when `user.admin` is false,
-      // not when the settings fetch itself is unauthorized.
-      // Bug location: frontend/src/components/guild/GuildSettingsForm.tsx line 71-73
-      // Fix needed: read `error` from useGuildSettings() and render an access-denied message
-      // (or redirect) when it throws UnauthorizedError.
-      await screen.findByText(/loading/i, undefined, { timeout: 3000 });
+      await screen.findByText(/access denied/i, undefined, { timeout: 3000 });
+      expect(screen.queryByText(/^loading…$/i)).toBeNull();
     } finally {
       restore();
     }

--- a/frontend/src/components/event/EventDetail.tsx
+++ b/frontend/src/components/event/EventDetail.tsx
@@ -22,11 +22,12 @@ import {
   useEvent,
 } from "@/lib/hooks";
 import type { Attendee, RsvpStatus } from "@/lib/types";
+import { ApiError } from "@/lib/api";
 import { PencilIcon } from "@/components/icons/PencilIcon";
 
 export function EventDetail({ id }: { id: string }) {
   const router = useRouter();
-  const { data, mutate, isLoading } = useEvent(id);
+  const { data, mutate, isLoading, error } = useEvent(id);
   const { data: me } = useCurrentUser();
   const guild = useActiveGuild();
   const [pendingRemove, setPendingRemove] = useState<Attendee | null>(null);
@@ -44,7 +45,30 @@ export function EventDetail({ id }: { id: string }) {
     }
   };
 
-  if (isLoading || !data) {
+  if (isLoading && !data && !error) {
+    return <div className="mx-auto max-w-[1200px] p-8 text-mute">loading…</div>;
+  }
+
+  if (error) {
+    const is404 = error instanceof ApiError && error.status === 404;
+    return (
+      <div className="mx-auto max-w-[640px] px-4 py-16 text-center">
+        <h1 className="text-[32px] font-extrabold tracking-[-0.04em]">
+          {is404 ? "event not found" : "couldn't load event"}
+        </h1>
+        <p className="mt-3 text-[17px] text-mute">
+          {is404
+            ? "This event doesn't exist or may have been removed."
+            : "Something went wrong. Try refreshing the page."}
+        </p>
+        <Link href="/" className="mt-6 inline-block text-[16px] font-semibold text-mute hover:text-ink">
+          ← back to events
+        </Link>
+      </div>
+    );
+  }
+
+  if (!data) {
     return <div className="mx-auto max-w-[1200px] p-8 text-mute">loading…</div>;
   }
 

--- a/frontend/src/components/guild/GuildSettingsForm.tsx
+++ b/frontend/src/components/guild/GuildSettingsForm.tsx
@@ -12,6 +12,7 @@ import {
   useCurrentUser,
   useGuildSettings,
 } from "@/lib/hooks";
+import { UnauthorizedError } from "@/lib/api";
 import {
   fetchPlaceDetails,
   geocodePlace,
@@ -23,7 +24,7 @@ export function GuildSettingsForm({ guildId }: { guildId: string }) {
   const router = useRouter();
   const { data: user } = useCurrentUser();
   const activeGuild = useActiveGuild();
-  const { data: settings, isLoading } = useGuildSettings(guildId);
+  const { data: settings, isLoading, error } = useGuildSettings(guildId);
   const sessionToken = useMemo(newPlacesSessionToken, []);
 
   const [primaryLocation, setPrimaryLocation] = useState("");
@@ -68,7 +69,30 @@ export function GuildSettingsForm({ guildId }: { guildId: string }) {
     }
   };
 
-  if (isLoading || !settings) {
+  if (isLoading && !settings && !error) {
+    return <div className="mx-auto max-w-[820px] p-8 text-mute">loading…</div>;
+  }
+
+  if (error) {
+    const isUnauthorized = error instanceof UnauthorizedError;
+    return (
+      <div className="mx-auto max-w-[640px] px-4 py-16 text-center">
+        <h1 className="text-[32px] font-extrabold tracking-[-0.04em]">
+          {isUnauthorized ? "access denied" : "couldn't load settings"}
+        </h1>
+        <p className="mt-3 text-[17px] text-mute">
+          {isUnauthorized
+            ? "You don't have permission to view server settings."
+            : "Something went wrong. Try refreshing the page."}
+        </p>
+        <Link href="/" className="mt-6 inline-block text-[16px] font-semibold text-mute hover:text-ink">
+          ← back
+        </Link>
+      </div>
+    );
+  }
+
+  if (!settings) {
     return <div className="mx-auto max-w-[820px] p-8 text-mute">loading…</div>;
   }
 


### PR DESCRIPTION
EventDetail now reads error from useEvent() and shows a "event not found" panel on 404 or a generic retry message on other errors instead of staying in the loading branch forever. GuildSettingsForm now reads error from useGuildSettings() and shows an "access denied" panel on UnauthorizedError or a generic error panel on other failures. Tests updated to assert the new error-UI text and confirm "loading…" is absent.